### PR TITLE
fixed NaN percent and React false-positive mutation warning

### DIFF
--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -37,7 +37,7 @@ module.exports = function HTMLReportBodySummary(props: FlowCoverageReportProps) 
             /* eslint-disable camelcase */
             covered_count: fileSummary.expressions.covered_count,
             uncovered_count: fileSummary.expressions.uncovered_count,
-            percent: fileSummary.percent || NaN
+            percent: fileSummary.percent
             /* eslint-enable camelcase */
           };
           return <FlowCoverageFileTableRow key={key} {...fileRowProps}/>;

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -15,10 +15,12 @@ function getCoveredPercent(
   }
 ) {
   const total = covered_count + uncovered_count;
-  let percent = Math.floor(covered_count / total * 100);
-  percent = isNaN(percent) ? 0 : percent;
 
-  return percent;
+  if (total === 0) {
+    return 100;
+  }
+
+  return Math.floor(covered_count / total * 100);
 }
 /* eslint-disable-line camelcase */
 exports.getCoveredPercent = getCoveredPercent;

--- a/src/test/unit/test-flow.js
+++ b/src/test/unit/test-flow.js
@@ -264,3 +264,13 @@ test('collectFlowCoverage', async function (t) {
   t.is(exec.callCount, 5);
   t.is(glob.callCount, 2);
 });
+
+test('getCoveredPercent', function (t) {
+  const flow = mockRequire.reRequire(LIB_FLOW);
+
+  /* eslint-disable camelcase */
+  t.is(flow.getCoveredPercent({covered_count: 0, uncovered_count: 0}), 100);
+  t.is(flow.getCoveredPercent({covered_count: 0, uncovered_count: 10}), 0);
+  t.is(flow.getCoveredPercent({covered_count: 3, uncovered_count: 11}), 21);
+  /* eslint-enable camelcase */
+});


### PR DESCRIPTION
relates to facebook/react#7424 — when coverage percent is 0, `HTMLReportBodySummary` defaults it again to NaN, which causes React to trigger false-positive child mutation warning.

also, i think percentage should be 100 if total number of lines is 0. any thoughts?
also, added test for `getCoveredPercent` :)