### PR TITLE
Promise.all -> sequential

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "glob": "7.0.5",
     "mkdirp": "0.5.1",
+    "promise-sequential": "^1.1.1",
     "react": "15.3.1",
     "react-dom": "15.3.1",
     "terminal-table": "0.0.12",

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -2,6 +2,7 @@
 
 // @flow
 
+import sequential from 'promise-sequential';
 import {exec, glob} from './promisified';
 
 // getCoveredPercent helper.
@@ -177,8 +178,8 @@ exports.collectFlowCoverage = function (
     function collectCoverageAndGenerateReportForGlob(globIncludePattern) {
       return glob(globIncludePattern, {cwd: projectDir, root: projectDir})
         .then(files => {
-          return Promise.all(
-            files.map(filename =>
+          return sequential(
+            files.map(filename => () =>
               collectFlowCoverageForFile(
                 flowCommandPath, projectDir, filename
               ).then((data: FlowCoverageJSONData) => {
@@ -199,8 +200,7 @@ exports.collectFlowCoverage = function (
         });
     }
 
-    return Promise
-      .all(globIncludePatterns.map(collectCoverageAndGenerateReportForGlob))
+    return sequential(globIncludePatterns.map(pattern => () => collectCoverageAndGenerateReportForGlob(pattern)))
       .then(() => {
         coverageSummaryData.percent = getCoveredPercent(coverageSummaryData);
 


### PR DESCRIPTION
this one is a little bit more controversial :)

the problem is that `collectFlowCoverage` uses `Promise.all()` to wait for multiple promises resolution, which simultaneously fires `child_process.exec` for every matched file. on my MacBook Pro this process quickly reaches ulimit and produces errors like this one:

```
Error while generating Flow Coverage Report: Error: spawn /bin/sh EAGAIN Error: spawn /bin/sh EAGAIN
    at exports._errnoException (util.js:1026:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

so the first thing that comes to mind — use sequential promise resolution, although it is significantly slows down generation time on small projects.
an alternate solution would be to use something like [promise-limit](https://github.com/featurist/promise-limit) to allow some degree of concurrency, but keep it limited.