### PR TITLE
Expose the `--output-dir` on the cli

### DIFF
--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -63,6 +63,13 @@ module.exports = {
         describe: 'the minimum coverage percent requested.',
         default: 80
       })
+      // --output-dir "/var/public_html/flow-coverage"
+      .option('output-dir', {
+        alias: 'o',
+        type: 'string',
+        describe: 'output html or json files to this folder relative to project-dir',
+        default: './flow-coverage'
+      })
       .check(argv => {
         argv.includeGlob = toArray(argv.includeGlob);
 

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -8,6 +8,7 @@ exports.run = () => {
     flowCommandPath: args.flowCommandPath,
     projectDir: args.projectDir,
     globIncludePatterns: args.includeGlob,
+    outputDir: args.outputDir,
     reportTypes: args.type,
     threshold: args.threshold
   }).catch(err => {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -14,7 +14,7 @@ export type FlowCoverageReportType = 'json' | 'text' | 'html';
 
 export type FlowCoverageReportOptions = {
   projectDir: string,
-  flowCommandPath?: string,
+  flowCommandPath: string,
   globIncludePatterns: Array<string>,
   outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -35,10 +35,10 @@ function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   var projectDir = opts.projectDir;
 
   opts.flowCommandPath = opts.flowCommandPath || 'flow';
-  opts.outputDir = opts.outputDir || './flow-coverage'
-  opts.outputDir = opts.outputDir.slice(0, 2) === './'
-    ? path.resolve(path.join(projectDir, opts.outputDir))
-    : opts.outputDir;
+  opts.outputDir = opts.outputDir || './flow-coverage';
+  opts.outputDir = opts.outputDir.slice(0, 2) === './' ?
+    path.resolve(path.join(projectDir, opts.outputDir)) :
+    opts.outputDir;
   opts.globIncludePatterns = opts.globIncludePatterns || [];
 
   // Apply validation checks.

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -16,7 +16,7 @@ export type FlowCoverageReportOptions = {
   projectDir: string,
   flowCommandPath?: string,
   globIncludePatterns: Array<string>,
-  outputDir?: string,
+  outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
   threshold?: number
 };
@@ -35,7 +35,10 @@ function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   var projectDir = opts.projectDir;
 
   opts.flowCommandPath = opts.flowCommandPath || 'flow';
-  opts.outputDir = opts.outputDir || path.join(projectDir, 'flow-coverage');
+  opts.outputDir = opts.outputDir || './flow-coverage'
+  opts.outputDir = opts.outputDir.slice(0, 2) === './'
+    ? path.resolve(path.join(projectDir, opts.outputDir))
+    : opts.outputDir;
   opts.globIncludePatterns = opts.globIncludePatterns || [];
 
   // Apply validation checks.


### PR DESCRIPTION
Add `--output-dir` as a argument flag. 

If output-dir is an absolute path that path is used.
If output-dir is a relative path, then it's resolved relative to the `--project-dir` argument.
If output-dir is omitted then the default of `'./flow-coverage'` is used. This is relative to the `--project-dir`. This is the same place were output would go as before.
