### PR TITLE
Cleanup old files before babel comes and makes new ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "prepublish": "npm run build",
-    "build": "babel -d dist src --source-maps",
+    "build": "rm -Rf dist && babel -d dist src --source-maps",
     "test": "cross-env NODE_ENV=test npm run build && npm run lint && npm run ava && npm run flow-coverage",
     "flow-coverage": "bin/flow-coverage-report.js -i 'src/lib/**/*.js' -i 'src/lib/**/*.jsx' -t html -t json -t text",
     "ava": "nyc ava --verbose",


### PR DESCRIPTION
`babel` doesn't clean this folder for us, so if something like a test file is renamed/removed the old one would stick around and get picked up by the test runner.
