### PR TITLE
chore: release 0.2.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-prefix=''

--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ or
 $ npm install --save-dev flow-coverage-report
 ```
 
-Run the flow reporter
+Run the flow reporter (`-i` configures the include globs, `-x` the exclude patterns,
+and `-t` the report types enabled):
 
 ```
-flow-coverage-report -i 'src/**/*.js' -i 'src/**/*.jsx' -t html -t json -t text
+flow-coverage-report -i 'src/**/*.js' -i 'src/**/*.jsx' -x 'src/test/**' -t html -t json -t text
 ```
 
 If the **flow** executable is not in your PATH, you can specified it using the
@@ -36,6 +37,12 @@ If the **flow** executable is not in your PATH, you can specified it using the
 
 ```
 flow-coverage-report -f /path/to/flow ...
+```
+
+To customize the output dir (which defaults to `flow-coverage/`). you can use the `-o` option:
+
+```
+flow-coverage-report -o my-custom-flow-coverage-dir/
 ```
 
 ## Background
@@ -66,3 +73,30 @@ You have just found it ;-)
 [screenshot-text]: https://raw.githubusercontent.com/rpl/flow-coverage-report/master/doc/screenshot-text.png
 [screenshot-summary]: https://raw.githubusercontent.com/rpl/flow-coverage-report/master/doc/screenshot-summary.png
 [screenshot-sourcefile]: https://raw.githubusercontent.com/rpl/flow-coverage-report/master/doc/screenshot-sourcefile.png
+
+## Changelog
+
+### 0.2.0
+
+Fixes needed to be able to generate flow coverage reports on larger projects (and projects with flow issues) and new configuration options:
+
+- fix: fixed NaN percent and React false-positive mutation warning (thanks to Ilia Saulenko)
+- feat: new -o cli option to customize the output dir (thanks to Ryan Albrecht)
+- fix: cleanup old dirs before a new babel build (thanks to Ryan Albrecht)
+- fix: fixed issues with larger projects and projects with flow issues (thanks to Ilia Saulenko and Ryan Albrecht for the help hunting this issue down)
+- feat: new -x cli option to exclude files from the coverage report
+- fix: fixed report-text rendering issues on larger number of files
+- feat: highlight files with errors and no coverage data in the reports
+- feat: included URL to the generated HTML report in the console output (thanks to Jason Laster)
+
+Thanks to Ilia Saulenko, Ryan Albrecht and Jason Laster for their help on this new release.
+
+### 0.1.0
+
+Initial prototype release:
+
+- collect and report coverage data as json, text and html
+- navigable sourcefile coverage html view based on CodeMirror
+- run unit tests on travis
+
+Thanks to Kumar McMillan and Andy MacKay for their advice and support, this project and its github repo wouldn't exist without you.

--- a/assets/index.js
+++ b/assets/index.js
@@ -2,4 +2,6 @@
 
 $(function () {
   $("table").tablesort();
+
+  $('td.error .attention.icon').popup({inline: true});
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-coverage-report",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Generate an HTML report of the flow coverage data",
   "main": "dist/lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mkdirp": "0.5.1",
     "react": "15.3.1",
     "react-dom": "15.3.1",
+    "temp": "0.8.3",
     "terminal-table": "0.0.12",
     "yargs": "5.0.0"
   },
@@ -43,6 +44,7 @@
     "babel-core": "6.13.2",
     "babel-plugin-istanbul": "2.0.0",
     "babel-plugin-transform-flow-strip-types": "6.8.0",
+    "babel-plugin-transform-runtime": "6.15.0",
     "babel-preset-es2015": "6.13.2",
     "babel-preset-react": "6.11.1",
     "babel-preset-stage-2": "6.13.0",
@@ -91,7 +93,14 @@
       "react"
     ],
     "plugins": [
-      "transform-flow-strip-types"
+      "transform-flow-strip-types",
+      [
+        "transform-runtime",
+        {
+          "polyfill": false,
+          "regenerator": true
+        }
+      ]
     ],
     "ignore": [
       "assets/"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-config-xo-react": "0.9.0",
     "eslint-plugin-flowtype": "2.11.0",
     "eslint-plugin-react": "6.1.2",
-    "flow-bin": "0.30.0",
+    "flow-bin": "0.33.0",
     "mock-require": "1.3.0",
     "nyc": "8.0.0",
     "react-addons-test-utils": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
     "assets/**/*"
   ],
   "scripts": {
-    "prepublish": "npm run build",
-    "build": "babel -d dist src --source-maps",
-    "test": "cross-env NODE_ENV=test npm run build && npm run lint && npm run ava && npm run flow-coverage",
-    "flow-coverage": "bin/flow-coverage-report.js -i 'src/lib/**/*.js' -i 'src/lib/**/*.jsx' -t html -t json -t text",
     "ava": "nyc ava --verbose",
-    "lint": "xo && flow check"
+    "build": "babel -d dist src --source-maps",
+    "flow-coverage": "bin/flow-coverage-report.js -i 'src/lib/**/*.js' -i 'src/lib/**/*.jsx' -t html -t json -t text",
+    "flow-check": "flow check",
+    "lint": "xo --reporter=compact",
+    "prepublish": "npm run build",
+    "test": "cross-env NODE_ENV=test npm run build && npm run lint && npm run flow-check && npm run ava && npm run flow-coverage"
   },
   "keywords": [
     "flowtype",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Luca Greco <lgreco@mozilla.com>",
   "license": "MPL-2.0",
   "dependencies": {
+    "babel-runtime": "6.11.6",
     "glob": "7.0.5",
     "minimatch": "3.0.3",
     "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Luca Greco <lgreco@mozilla.com>",
   "license": "MPL-2.0",
   "dependencies": {
+    "array.prototype.find": "2.0.0",
     "babel-runtime": "6.11.6",
     "glob": "7.0.5",
     "minimatch": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "ava": "nyc ava --verbose",
-    "build": "babel -d dist src --source-maps",
+    "build": "rm -Rf dist && babel -d dist src --source-maps",
     "flow-coverage": "bin/flow-coverage-report.js -i 'src/lib/**/*.js' -i 'src/lib/**/*.jsx' -t html -t json -t text",
     "flow-check": "flow check",
     "lint": "xo --reporter=compact",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MPL-2.0",
   "dependencies": {
     "glob": "7.0.5",
+    "minimatch": "3.0.3",
     "mkdirp": "0.5.1",
     "react": "15.3.1",
     "react-dom": "15.3.1",

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -63,6 +63,13 @@ module.exports = {
         describe: 'the minimum coverage percent requested.',
         default: 80
       })
+      // --output-dir "/var/public_html/flow-coverage"
+      .option('output-dir', {
+        alias: 'o',
+        type: 'string',
+        describe: 'output html or json files to this folder relative to project-dir',
+        default: './flow-coverage'
+      })
       .check(argv => {
         argv.includeGlob = toArray(argv.includeGlob);
 

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -58,6 +58,12 @@ module.exports = {
         describe: 'include the files selected by the specified glob',
         default: '**/*.js'
       })
+      .option('exclude-glob', {
+        alias: 'x',
+        type: 'string',
+        describe: 'exclude the files selected by the specified glob',
+        default: 'node_modules/**'
+      })
       .options('threshold', {
         type: 'number',
         describe: 'the minimum coverage percent requested.',

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -8,6 +8,7 @@ exports.run = () => {
     flowCommandPath: args.flowCommandPath,
     projectDir: args.projectDir,
     globIncludePatterns: args.includeGlob,
+    globExcludePatterns: args.excludeGlob,
     outputDir: args.outputDir,
     reportTypes: args.type,
     threshold: args.threshold

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -8,6 +8,7 @@ exports.run = () => {
     flowCommandPath: args.flowCommandPath,
     projectDir: args.projectDir,
     globIncludePatterns: args.includeGlob,
+    outputDir: args.outputDir,
     reportTypes: args.type,
     threshold: args.threshold
   }).catch(err => {

--- a/src/lib/components/body-coverage-sourcefile.jsx
+++ b/src/lib/components/body-coverage-sourcefile.jsx
@@ -91,6 +91,10 @@ module.exports = function HTMLReportBodySourceFile(props: FlowCoverageReportProp
                 {...{
                   disableLink: true,
                   filename: fileName,
+                  flowCoverageParsingError: coverageData.flowCoverageParsingError,
+                  flowCoverageError: coverageData.flowCoverageError,
+                  flowCoverageException: coverageData.flowCoverageException,
+                  flowCoverageStderr: coverageData.flowCoverageStderr,
                   isError: coverageData.isError,
                   percent,
                   /* eslint-disable camelcase */

--- a/src/lib/components/body-coverage-sourcefile.jsx
+++ b/src/lib/components/body-coverage-sourcefile.jsx
@@ -91,10 +91,11 @@ module.exports = function HTMLReportBodySourceFile(props: FlowCoverageReportProp
                 {...{
                   disableLink: true,
                   filename: fileName,
+                  isError: coverageData.isError,
+                  percent,
                   /* eslint-disable camelcase */
-                  covered_count: covered_count,
-                  uncovered_count: uncovered_count,
-                  percent: percent
+                  covered_count,
+                  uncovered_count
                   /* eslint-enable camelcase */
                 }}
                 />

--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -34,11 +34,16 @@ module.exports = function HTMLReportBodySummary(props: FlowCoverageReportProps) 
           const key = filename;
           const fileRowProps = {
             filename: filename,
+            isError: fileSummary.isError,
+            flowCoverageParsingError: fileSummary.flowCoverageParsingError,
+            flowCoverageError: fileSummary.flowCoverageError,
+            flowCoverageException: fileSummary.flowCoverageException,
+            flowCoverageStderr: fileSummary.flowCoverageStderr,
+
+            percent: fileSummary.percent,
             /* eslint-disable camelcase */
             covered_count: fileSummary.expressions.covered_count,
-            uncovered_count: fileSummary.expressions.uncovered_count,
-            percent: fileSummary.percent,
-            isError: fileSummary.isError
+            uncovered_count: fileSummary.expressions.uncovered_count
             /* eslint-enable camelcase */
           };
           return <FlowCoverageFileTableRow key={key} {...fileRowProps}/>;

--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -37,7 +37,8 @@ module.exports = function HTMLReportBodySummary(props: FlowCoverageReportProps) 
             /* eslint-disable camelcase */
             covered_count: fileSummary.expressions.covered_count,
             uncovered_count: fileSummary.expressions.uncovered_count,
-            percent: fileSummary.percent
+            percent: fileSummary.percent,
+            isError: fileSummary.isError
             /* eslint-enable camelcase */
           };
           return <FlowCoverageFileTableRow key={key} {...fileRowProps}/>;

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -14,7 +14,8 @@ module.exports = function FlowCoverageFileTableRow(
   props: {
     filename: string, covered_count: number, uncovered_count: number,
     percent: number, disableLink?: boolean, threshold?: number,
-    isError: boolean,
+    isError: boolean, flowCoverageError?: ?string, flowCoverageParsingError?: ?string,
+    flowCoverageException?: ?string, flowCoverageStderr?: ?string|?Buffer,
   }
 ) {
   /* eslint-disable camelcase */
@@ -33,8 +34,39 @@ module.exports = function FlowCoverageFileTableRow(
 
   let className = percent >= threshold ? 'positive' : 'negative';
 
+  let errorPopup;
+
   if (isError) {
     className = 'error';
+    let errorType;
+    let errorContent;
+
+    if (props.flowCoverageError) {
+      errorType = 'flow coverage';
+      errorContent = <pre>{props.flowCoverageError}</pre>;
+    }
+
+    if (props.flowCoverageParsingError) {
+      errorType = 'JSON Parsing';
+      errorContent = <pre>{props.flowCoverageParsingError}</pre>;
+    }
+
+    if (props.flowCoverageException) {
+      errorType = 'Flow command unexpected error';
+      errorContent = <pre>{props.flowCoverageException}</pre>;
+    }
+
+    if (props.flowCoverageStderr) {
+      errorType = 'Flow command stderr';
+      errorContent = <pre>{props.flowCoverageStderr}</pre>;
+    }
+
+    errorPopup = (
+      <div className="ui popup">
+        <div className="header">Flow Error: {errorType}</div>
+        <div>{errorContent}</div>
+      </div>
+    );
   }
 
   return (
@@ -45,7 +77,11 @@ module.exports = function FlowCoverageFileTableRow(
       <td key="percent" className={isError && 'error'}>
         {
           isError ?
-            <span><i className="attention icon"/> Error</span> :
+            <span>
+              <i className="attention icon" data-position="bottom right"/>
+              Error
+              {errorPopup}
+            </span> :
             <span>{percent} %</span>
         }
       </td>

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -13,14 +13,15 @@ function LinkToSourceFileReport(props: {targetFilename: string}) {
 module.exports = function FlowCoverageFileTableRow(
   props: {
     filename: string, covered_count: number, uncovered_count: number,
-    percent: number, disableLink?: boolean, threshold?: number
+    percent: number, disableLink?: boolean, threshold?: number,
+    isError: boolean,
   }
 ) {
   /* eslint-disable camelcase */
   const {
     filename,
     covered_count, uncovered_count,
-    percent
+    percent, isError
   } = props;
 
   let {
@@ -30,12 +31,24 @@ module.exports = function FlowCoverageFileTableRow(
   disableLink = props.disableLink;
   threshold = props.threshold || 80;
 
+  let className = percent >= threshold ? 'positive' : 'negative';
+
+  if (isError) {
+    className = 'error';
+  }
+
   return (
-    <tr key={filename} className={percent >= threshold ? 'positive' : 'negative'}>
+    <tr key={filename} className={className}>
       <td key="filename" className={disableLink ? '' : 'selectable'}>
         {disableLink ? filename : <LinkToSourceFileReport targetFilename={filename}/>}
       </td>
-      <td key="percent"> {percent} %</td>
+      <td key="percent" className={isError && 'error'}>
+        {
+          isError ?
+            <span><i className="attention icon"/> Error</span> :
+            <span>{percent} %</span>
+        }
+      </td>
       <td key="total"> {covered_count + uncovered_count} </td>
       <td key="covered"> {covered_count} </td>
       <td key="uncovered"> {uncovered_count} </td>

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -6,6 +6,11 @@ import minimatch from 'minimatch';
 import temp from 'temp';
 import {exec, glob, writeFile} from './promisified';
 
+// Load the Array.prototype.find polyfill if needed (e.g. nodejs 0.12).
+if (!Array.prototype.find) {
+  require('array.prototype.find').shim();
+}
+
 // getCoveredPercent helper.
 
 /* eslint-disable camelcase */

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -263,6 +263,7 @@ export type FlowCoverageSummaryData = {
   generatedAt: string,
   flowStatus: FlowStatus,
   globIncludePatterns: Array<string>,
+  globExcludePatterns: Array<string>,
   files: {
     [key: string]: FlowCoverageJSONData
   }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -22,7 +22,8 @@ export type FlowCoverageReportOptions = {
   globExcludePatterns: Array<string>,
   outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
-  threshold?: number
+  threshold?: number,
+  log: Function
 };
 
 // Default timeout for flow coverage commands.
@@ -49,7 +50,7 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   }
 
   opts.flowCommandPath = opts.flowCommandPath || 'flow';
-  opts.flowCommandTimeout = opts.glowCommandTimeout || DEFAULT_FLOW_TIMEOUT; // defaults to 15s
+  opts.flowCommandTimeout = opts.flowCommandTimeout || DEFAULT_FLOW_TIMEOUT; // defaults to 15s
   opts.outputDir = opts.outputDir || './flow-coverage';
   opts.outputDir = path.isAbsolute(opts.outputDir) ?
     opts.outputDir : path.resolve(path.join(projectDir, opts.outputDir));

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -16,9 +16,9 @@ export type FlowCoverageReportType = 'json' | 'text' | 'html';
 
 export type FlowCoverageReportOptions = {
   projectDir: string,
-  flowCommandPath?: string,
+  flowCommandPath: string,
   globIncludePatterns: Array<string>,
-  outputDir?: string,
+  outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
   threshold?: number
 };
@@ -39,7 +39,10 @@ function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   return withTmpDir('flow-coverage-report')
     .then(dirPath => {
       opts.flowCommandPath = opts.flowCommandPath || 'flow';
-      opts.outputDir = opts.outputDir || path.join(projectDir, 'flow-coverage');
+      opts.outputDir = opts.outputDir || './flow-coverage';
+      opts.outputDir = opts.outputDir.slice(0, 2) === './' ?
+        path.resolve(path.join(projectDir, opts.outputDir)) :
+        opts.outputDir;
       opts.globIncludePatterns = opts.globIncludePatterns || [];
 
       // Apply validation checks.

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -19,6 +19,7 @@ export type FlowCoverageReportOptions = {
   flowCommandPath: string,
   flowCommandTimeout: number,
   globIncludePatterns: Array<string>,
+  globExcludePatterns: Array<string>,
   outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
   threshold?: number
@@ -54,6 +55,11 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
     path.resolve(path.join(projectDir, opts.outputDir)) :
     opts.outputDir;
   opts.globIncludePatterns = opts.globIncludePatterns || [];
+  opts.globExcludePatterns = opts.globExcludePatterns || [];
+
+  if (!Array.isArray(opts.globExcludePatterns)) {
+    opts.globExcludePatterns = [opts.globExcludePatterns];
+  }
 
   // Apply validation checks.
   if (!projectDir) {
@@ -70,7 +76,7 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
 
   let coverageData: FlowCoverageSummaryData = await collectFlowCoverage(
     opts.flowCommandPath, opts.flowCommandTimeout,
-    opts.projectDir, opts.globIncludePatterns,
+    opts.projectDir, opts.globIncludePatterns, opts.globExcludePatterns,
     opts.threshold, tmpDirPath
   );
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -92,7 +92,9 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   }
 
   if (reportTypes.indexOf('html') >= 0) {
-    reportResults.push(reportHTML.generate(coverageData, opts));
+    reportResults.push(reportHTML.generate(coverageData, opts).then(() => {
+      console.log(`View generated HTML Report at file://${opts.outputDir}/index.html`);
+    }));
   }
 
   return Promise.all(reportResults).then(() => {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -51,9 +51,8 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   opts.flowCommandPath = opts.flowCommandPath || 'flow';
   opts.flowCommandTimeout = opts.glowCommandTimeout || DEFAULT_FLOW_TIMEOUT; // defaults to 15s
   opts.outputDir = opts.outputDir || './flow-coverage';
-  opts.outputDir = opts.outputDir.slice(0, 2) === './' ?
-    path.resolve(path.join(projectDir, opts.outputDir)) :
-    opts.outputDir;
+  opts.outputDir = path.isAbsolute(opts.outputDir) ?
+    opts.outputDir : path.resolve(path.join(projectDir, opts.outputDir));
   opts.globIncludePatterns = opts.globIncludePatterns || [];
   opts.globExcludePatterns = opts.globExcludePatterns || [];
 

--- a/src/lib/promisified.js
+++ b/src/lib/promisified.js
@@ -11,7 +11,7 @@ import temp from 'temp';
 // Automatically cleanup temp file on process.exit
 temp.track();
 
-export type ExecResult = {err?: Error, stdout?: Buffer, stderr?: Buffer};
+export type ExecResult = {err?: Error, stdout?: string|Buffer, stderr?: string|Buffer};
 export type ExecOptions = child_process$execOpts; // eslint-disable-line camelcase
 export type ExecExtras = {dontReject?: boolean};
 

--- a/src/lib/promisified.js
+++ b/src/lib/promisified.js
@@ -6,6 +6,10 @@ import {exec} from 'child_process';
 import fs from 'fs';
 import glob from 'glob';
 import mkdirp from 'mkdirp';
+import temp from 'temp';
+
+// Automatically cleanup temp file on process.exit
+temp.track();
 
 export type ExecResult = {err?: Error, stdout?: Buffer, stderr?: Buffer};
 export type ExecOptions = child_process$execOpts; // eslint-disable-line camelcase
@@ -80,6 +84,18 @@ exports.glob = function (pattern: string, options: GlobOptions): Promise<GlobFil
         reject(err);
       } else {
         resolve(files);
+      }
+    });
+  });
+};
+
+exports.withTmpDir = function (tempFileId: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    temp.mkdir(tempFileId, (err, dirPath) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(dirPath);
       }
     });
   });

--- a/src/lib/report-html.js
+++ b/src/lib/report-html.js
@@ -149,7 +149,8 @@ function renderHTMLReport(opt/* : Object */) {
                       'codemirror-javascript-mode.js',
                       'codemirror-annotatescrollbar-addon.js',
                       'codemirror-simplescrollbars-addon.js',
-                      'flow-highlight-source.js'
+                      'flow-highlight-source.js',
+                      'index.js'
                     ].map(prefixAssets).map(toRelative)
                   }
                 }));

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -11,7 +11,7 @@ import type {FlowCoverageReportOptions} from './index';
 function renderTextReport(
   coverageData: FlowCoverageSummaryData,
   opts: FlowCoverageReportOptions
-) {
+): Promise<void> {
   const print = opts.log || console.log.bind(console);
 
   const filesTable = new Table({
@@ -94,7 +94,7 @@ function renderTextReport(
 
   summaryTable.push(['project', 'percent', 'total', 'covered', 'uncovered']);
   const summaryTotal = coverageData.covered_count + coverageData.uncovered_count;
-  let summaryPercent = coverageData.percent || NaN;
+  let summaryPercent = coverageData.percent || 0;
 
   let summaryColor;
   if (summaryPercent >= (opts.threshold || 80)) {
@@ -117,17 +117,26 @@ function renderTextReport(
     align: 'right'
   });
 
+  const waitForDrain = new Promise(resolve => {
+    if (opts.log) {
+      resolve();
+    } else {
+      process.stdout.on('drain', resolve);
+    }
+  });
+
   print(String(filesTable));
   print(String(summaryTablePre));
   print(String(summaryTable));
+
+  return waitForDrain;
 }
 
 function generateFlowCoverageReportText(
   coverageData: FlowCoverageSummaryData,
   opts: Object
-) {
-  renderTextReport(coverageData, opts);
-  return Promise.resolve([coverageData, opts]);
+): Promise<void> {
+  return renderTextReport(coverageData, opts);
 }
 
 module.exports = {

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -25,6 +25,12 @@ function renderTextReport(
   for (const filename of Object.keys(coverageData.files).sort()) {
     row += 1;
     const data = coverageData.files[filename];
+
+    if (data.isError) {
+      // Skip files without coverage data.
+      continue;
+    }
+
     const covered = data.expressions.covered_count;
     const uncovered = data.expressions.uncovered_count;
     let percent = data.percent || NaN;

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -26,23 +26,24 @@ function renderTextReport(
     row += 1;
     const data = coverageData.files[filename];
 
-    if (data.isError) {
-      // Skip files without coverage data.
-      continue;
-    }
-
     const covered = data.expressions.covered_count;
     const uncovered = data.expressions.uncovered_count;
     let percent = data.percent || NaN;
 
     filesTable.push([
-      filename, percent + ' %', covered + uncovered, covered, uncovered
+      filename,
+      data.isError ? '\u26A0 Error' : percent + ' %',
+      covered + uncovered, covered, uncovered
     ]);
 
     let rowColor;
     if (percent >= (opts.threshold || 80)) {
       rowColor = 'green';
     } else {
+      rowColor = 'red';
+    }
+
+    if (data.isError) {
       rowColor = 'red';
     }
 

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -67,6 +67,10 @@ function renderTextReport(
     coverageData.globIncludePatterns.join(', ')
   ]);
   summaryTablePre.push([
+    'excluded glob patterns:',
+    (coverageData.globExcludePatterns || []).join(', ')
+  ]);
+  summaryTablePre.push([
     'threshold:',
     coverageData.threshold
   ]);

--- a/src/test/unit/test-flow.js
+++ b/src/test/unit/test-flow.js
@@ -78,7 +78,7 @@ test('checkFlowStatus resolves to flow types errors in json format',
 
     await t.throws(
       flow.checkFlowStatus('flow', '/fake/projectDir/', tmpDirPath),
-      'Invalid Flow status JSON format'
+      'Parsing error on Flow status JSON result: SyntaxError: Unexpected end of input'
     );
   }
 );

--- a/src/test/unit/test-flow.js
+++ b/src/test/unit/test-flow.js
@@ -87,7 +87,7 @@ test('checkFlowStatus resolves to flow types errors in json format',
 
     await t.throws(
       flow.checkFlowStatus('flow', '/fake/projectDir/', tmpDirPath),
-      'Parsing error on Flow status JSON result: SyntaxError: Unexpected end of input'
+      /Parsing error on Flow status JSON result: SyntaxError: Unexpected end/
     );
   }
 );

--- a/src/test/unit/test-react-components/test-coverage-file-table-row.js
+++ b/src/test/unit/test-react-components/test-coverage-file-table-row.js
@@ -39,4 +39,69 @@ test('<FlowCoverageFileTableRow />', t => {
   }
 });
 
+test('<FlowCoverageFileTableRow /> with errors', t => {
+  const FlowCoverageFileTableRow = require(REACT_COMPONENT);
+  const baseErrorProps = {
+    filename: 'fake-filename.js',
+    disableLink: true,
+    isError: true,
+
+    /* eslint-disable camelcase */
+    covered_count: 0,
+    uncovered_count: 0
+    /* eslint-enable camelcase */
+  };
+
+  const testErrorProp = (props, expectedErrorRegEx) => {
+    let wrapper = shallow(<FlowCoverageFileTableRow {...props}/>);
+
+    const expectedKeys = [
+      'filename', 'percent', 'total', 'covered', 'uncovered'
+    ];
+
+    t.is(wrapper.find('tr').length, 1);
+    t.true(wrapper.find('tr').hasClass('error'), 1);
+
+    t.is(wrapper.find('td').length, expectedKeys.length);
+
+    let i = 0;
+    for (const expectedKey of expectedKeys) {
+      t.is(wrapper.find('td').at(i).key(), expectedKey);
+      i++;
+    }
+
+    let errorIcon = wrapper.find('.attention.icon');
+    t.is(errorIcon.length, 1);
+
+    let errorPopup = wrapper.find('.ui.popup');
+    t.is(errorPopup.length, 1);
+
+    t.regex(errorPopup.text(), expectedErrorRegEx);
+  };
+
+  let flowCoverageErrorProps = {
+    ...baseErrorProps,
+    flowCoverageError: 'Fake Coverage Error'
+  };
+  testErrorProp(flowCoverageErrorProps, /Fake Coverage Error/);
+
+  let flowCoverageParsingErrorProps = {
+    ...baseErrorProps,
+    flowCoverageParsingError: 'Fake Parsing Error'
+  };
+  testErrorProp(flowCoverageParsingErrorProps, /Fake Parsing Error/);
+
+  let flowCoverageExceptionErrorProps = {
+    ...baseErrorProps,
+    flowCoverageException: 'Fake Coverage Exception'
+  };
+  testErrorProp(flowCoverageExceptionErrorProps, /Fake Coverage Exception/);
+
+  let flowCoverageUnrecognizedErrorProps = {
+    ...baseErrorProps,
+    flowCoverageStderr: 'Fake flow unrecognized error stderr'
+  };
+  testErrorProp(flowCoverageUnrecognizedErrorProps, /Fake flow unrecognized error stderr/);
+});
+
 test.todo('<FlowCoverageFileTableRow /> with missing props');


### PR DESCRIPTION
This PR prepares the relase of the version 0.2.0, minly focused of introducing fixes needed to be able to generate flow coverage reports on larger projects (and projects with flow issues) and new configuration options:
- fix: fixed NaN percent and React false-positive mutation warning (from #3 thanks to @mynameiswhm)
- feat: new -o cli option to customize the output dir (from #7 thanks to @ryan953)
- fix: cleanup old dirs before a new babel build (from #8 thanks to @ryan953)
- fix: fixed issues with larger projects and projects with flow issues (thanks to @mynameiswhm and @ryan953 for the help hunting this issue down in #4, #5 and #6)
- feat: new -x cli option to exclude files from the coverage report
- fix: fixed report-text rendering issues on larger number of files
- feat: highlight files with errors and no coverage data in the reports
- feat: included URL to the generated HTML report in the console output (thanks to @jasonLaster)
