### PR TITLE
feat: new -c/--concurrent-files CLI option

### DIFF
--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -5,11 +5,12 @@ exports.run = () => {
   const args = processArgv(process.argv);
 
   generateFlowCoverageReport({
+    concurrentFiles: args.concurrentFiles,
     flowCommandPath: args.flowCommandPath,
-    projectDir: args.projectDir,
-    globIncludePatterns: args.includeGlob,
     globExcludePatterns: args.excludeGlob,
+    globIncludePatterns: args.includeGlob,
     outputDir: args.outputDir,
+    projectDir: args.projectDir,
     reportTypes: args.type,
     threshold: args.threshold
   }).catch(err => {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -23,6 +23,7 @@ export type FlowCoverageReportOptions = {
   outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
   threshold?: number,
+  concurrentFiles?: number,
   log: Function
 };
 
@@ -77,7 +78,8 @@ async function generateFlowCoverageReport(opts: FlowCoverageReportOptions) {
   let coverageData: FlowCoverageSummaryData = await collectFlowCoverage(
     opts.flowCommandPath, opts.flowCommandTimeout,
     opts.projectDir, opts.globIncludePatterns, opts.globExcludePatterns,
-    opts.threshold, tmpDirPath
+    opts.threshold, opts.concurrentFiles || 1,
+    tmpDirPath
   );
 
   var reportResults = [];

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -74,6 +74,11 @@ function renderTextReport(
     'threshold:',
     coverageData.threshold
   ]);
+  summaryTablePre.push([
+    'concurrent files:',
+    coverageData.concurrentFiles
+  ]);
+
   summaryTablePre.push(['generated at:', coverageData.generatedAt]);
   summaryTablePre.push(['flow version:', coverageData.flowStatus.flowVersion]);
   summaryTablePre.push([
@@ -83,7 +88,7 @@ function renderTextReport(
       ' >= 50' : coverageData.flowStatus.errors.length) +
     ' errors)'
   ]);
-  summaryTablePre.attrRange({row: [3]}, {
+  summaryTablePre.attrRange({row: [6]}, {
     color: coverageData.flowStatus.passed ? 'green' : 'red'
   });
 

--- a/src/test/unit/test-flow.js
+++ b/src/test/unit/test-flow.js
@@ -244,7 +244,9 @@ test('collectFlowCoverageForFile resolve coverage data', async function (t) {
   mockRequire(NPM_TEMP, {path: tempPath});
   mockRequire(LIB_PROMISIFIED, {exec, writeFile});
 
+  const filename = 'src/fakeFilename.js';
   const fakeFlowCoverageData = {
+    filename,
     fakeCoverageData: {
       ok: true
     }
@@ -256,7 +258,6 @@ test('collectFlowCoverageForFile resolve coverage data', async function (t) {
   }));
 
   const flow = mockRequire.reRequire(LIB_FLOW);
-  const filename = 'src/fakeFilename.js';
 
   const res = await flow.collectFlowCoverageForFile(
     'flow', DEFAULT_FLOW_TIMEOUT, '/fake/projectDir', filename
@@ -339,7 +340,9 @@ test('collectFlowCoverage', async function (t) {
   ];
 
   const res = await flow.collectFlowCoverage(
-    'flow', DEFAULT_FLOW_TIMEOUT, '/projectDir', globIncludePatterns, globExcludePatterns,
+    'flow', DEFAULT_FLOW_TIMEOUT, '/projectDir',
+    globIncludePatterns, globExcludePatterns,
+    80, 5
   );
 
   t.is(typeof res.generatedAt, 'string');
@@ -352,8 +355,9 @@ test('collectFlowCoverage', async function (t) {
     flowStatus: {...fakeFlowStatus},
     globIncludePatterns,
     globExcludePatterns,
+    concurrentFiles: 5,
     percent: 50,
-    threshold: undefined,
+    threshold: 80,
     /* eslint-disable camelcase */
     covered_count: 4,
     uncovered_count: 4
@@ -382,6 +386,7 @@ test('collectFlowCoverage', async function (t) {
     delete resFiles[filename].expressions.uncovered_locs;
     t.deepEqual(resFiles[filename], {
       percent: 50,
+      filename,
       expressions: {
         /* eslint-disable camelcase */
         covered_count: 1,


### PR DESCRIPTION
This PR contains the changes needed to optionally submit multiple files to flow before waiting for their results.

As discussed in #6 it is possible that submitting multiple files to flow can speed up the coverage data collection step, but the right value is probably dependent from the performance of the machine that is running the flow, and a too high number can flood the running `flow` instance with too much data to process at once.

Using `1` as the default value is safest (especially while generating the report on CI slaves), but being able to tweak the number of concurrent files piped to flow can be a useful feature to use on a developer laptop.