### PR TITLE
Add links to GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
   ],
   "author": "Luca Greco <lgreco@mozilla.com>",
   "license": "MPL-2.0",
+  "homepage": "https://github.com/rpl/flow-coverage-report",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rpl/flow-coverage-report.git"
+  },
   "dependencies": {
     "array.prototype.find": "2.0.0",
     "babel-runtime": "6.11.6",


### PR DESCRIPTION
The aim of this change is to help people find the GitHub repository of this project, as it may not be obvious from the [npm page](https://www.npmjs.com/package/flow-coverage-report).