### PR TITLE
feat: optionally load config from package.json or json config file

### DIFF
--- a/assets/flow-coverage-report.css
+++ b/assets/flow-coverage-report.css
@@ -1,3 +1,7 @@
 .CodeMirror {
   border: 1px solid black;
 }
+
+.ui.grid.container {
+  padding-top: 4px;
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "ava": "nyc ava --verbose",
     "build": "rm -Rf dist && babel -d dist src --source-maps",
-    "flow-coverage": "bin/flow-coverage-report.js -i 'src/lib/**/*.js' -i 'src/lib/**/*.jsx' -t html -t json -t text",
+    "flow-coverage": "bin/flow-coverage-report.js",
     "flow-check": "flow check",
     "lint": "xo --reporter=compact",
     "prepublish": "npm run build",
@@ -41,8 +41,10 @@
     "glob": "7.0.5",
     "minimatch": "3.0.3",
     "mkdirp": "0.5.1",
+    "parse-json": "2.2.0",
     "react": "15.3.1",
     "react-dom": "15.3.1",
+    "strip-json-comments": "2.0.1",
     "temp": "0.8.3",
     "terminal-table": "0.0.12",
     "yargs": "5.0.0"
@@ -152,5 +154,14 @@
     "sourceMap": false,
     "instrument": false,
     "all": true
+  },
+  "flow-coverage-report": {
+    "includeGlob": [
+      "src/lib/**/*.js",
+      "src/lib/**/*.jsx"
+    ],
+    "type": [
+      "text", "html", "json"
+    ]
   }
 }

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -3,6 +3,8 @@ import yargs from 'yargs';
 
 import npm from '../../../package';
 
+import {defaultConfig} from './config';
+
 const examples = appName => `
 Examples:
 
@@ -31,19 +33,21 @@ module.exports = {
       .option('flow-command-path', {
         alias: 'f',
         type: 'string',
-        coerce: value => value.slice(0, 2) === './' ? path.resolve(value) : value
+        coerce: value => value.slice(0, 2) === './' ? path.resolve(value) : value,
+        describe: `path to the flow executable (defaults to "${defaultConfig.flowCommandPath}")`
       })
       // --type text
       .option('type', {
         alias: 't',
         type: 'choice',
-        choices: ['html', 'json', 'text']
+        choices: ['html', 'json', 'text'],
+        describe: `format of the generated reports (defaults to "${defaultConfig.type.join(', ')}")`
       })
       // --project-dir "/project/dir/path"
       .option('project-dir', {
         alias: 'p',
         type: 'string',
-        describe: 'select the project dir path'
+        describe: `select the project dir path (defaults to "${defaultConfig.projectDir}")`
       })
       // --include-glob "src/**/*.js"
       .option('include-glob', {
@@ -54,23 +58,24 @@ module.exports = {
       .option('exclude-glob', {
         alias: 'x',
         type: 'string',
-        describe: 'exclude the files selected by the specified glob'
+        describe: 'exclude the files selected by the specified glob ' +
+          `(defaults to "${defaultConfig.excludeGlob}")`
       })
       .options('threshold', {
         type: 'number',
-        describe: 'the minimum coverage percent requested.'
+        describe: `the minimum coverage percent requested (defaults to ${defaultConfig.threshold})`
       })
       // --output-dir "/var/public_html/flow-coverage"
       .option('output-dir', {
         alias: 'o',
         type: 'string',
-        describe: 'output html or json files to this folder relative to project-dir'
+        describe: `output html or json files to this folder relative to project-dir (defaults to "${defaultConfig.outputDir}")`
       })
       // --concurrent-files 5
       .option('concurrent-files', {
         alias: 'c',
         type: 'number',
-        describe: 'the maximum number of files concurrently submitted to flow'
+        describe: `the maximum number of files concurrently submitted to flow (defaults to ${defaultConfig.concurrentFiles})`
       })
       // --no-config
       .option('no-config', {

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -20,7 +20,6 @@ For more informations:
 module.exports = {
   processArgv(argv) {
     const appName = path.basename(argv[1]).split('.')[0];
-    const toArray = value => Array.isArray(value) ? value : [value];
 
     return yargs(argv).usage('Usage: $0 COMMAND PROJECTDIR [...globs]')
       .command('report', 'Generate Flow Coverage Report on file selected by the GLOB parameter')
@@ -32,93 +31,59 @@ module.exports = {
       .option('flow-command-path', {
         alias: 'f',
         type: 'string',
-        default: 'flow',
         coerce: value => value.slice(0, 2) === './' ? path.resolve(value) : value
       })
       // --type text
       .option('type', {
         alias: 't',
         type: 'choice',
-        choices: ['html', 'json', 'text'],
-        default: 'text'
-        // coerce: toArray
+        choices: ['html', 'json', 'text']
       })
       // --project-dir "/project/dir/path"
       .option('project-dir', {
         alias: 'p',
         type: 'string',
-        describe: 'select the project dir path',
-        default: process.cwd(),
-        coerce: path.resolve
+        describe: 'select the project dir path'
       })
       // --include-glob "src/**/*.js"
       .option('include-glob', {
         alias: 'i',
         type: 'string',
-        describe: 'include the files selected by the specified glob',
-        default: '**/*.js'
+        describe: 'include the files selected by the specified glob'
       })
       .option('exclude-glob', {
         alias: 'x',
         type: 'string',
-        describe: 'exclude the files selected by the specified glob',
-        default: 'node_modules/**'
+        describe: 'exclude the files selected by the specified glob'
       })
       .options('threshold', {
         type: 'number',
-        describe: 'the minimum coverage percent requested.',
-        default: 80
+        describe: 'the minimum coverage percent requested.'
       })
       // --output-dir "/var/public_html/flow-coverage"
       .option('output-dir', {
         alias: 'o',
         type: 'string',
-        describe: 'output html or json files to this folder relative to project-dir',
-        default: './flow-coverage'
+        describe: 'output html or json files to this folder relative to project-dir'
       })
       // --concurrent-files 5
       .option('concurrent-files', {
         alias: 'c',
         type: 'number',
-        describe: 'the maximum number of files concurrently submitted to flow',
-        default: 1
+        describe: 'the maximum number of files concurrently submitted to flow'
+      })
+      // --no-config
+      .option('no-config', {
+        type: 'boolean',
+        describe: 'do not load any config file from the project dir'
+      })
+      .option('config', {
+        type: 'string',
+        describe: 'file path of the config file to load'
       })
       .check(argv => {
-        argv.includeGlob = toArray(argv.includeGlob);
-
-        function raiseErrorIfArray(value, msg) {
-          if (Array.isArray(value)) {
-            throw new Error(`ERROR: Only one ${msg} can be specified.`);
-          }
-        }
-
-        const preventDuplicatedOptions = {
-          projectDir: 'project dir',
-          outputDir: 'output dir',
-          threshold: 'threshold',
-          flowCommandPath: 'flow command',
-          concurrentFiles: '--concurrent-files option'
-        };
-
-        for (const option of Object.keys(preventDuplicatedOptions)) {
-          const msg = preventDuplicatedOptions[option];
-          raiseErrorIfArray(argv[option], msg);
-        }
-
-        const {includeGlob} = argv;
-
-        if (!includeGlob || includeGlob.length === 0) {
-          throw new Error('ERROR: No glob has been specified.');
-        }
-
         if (argv._.length > 2) {
           throw new Error('ERROR: The include glob needs to be quoted.');
-        }
-
-        for (const glob of includeGlob) {
-          if (glob[0] === '!') {
-            throw new Error('ERROR: Only include glob syntax are supported.');
-          }
         }
 
         return true;

--- a/src/lib/cli/config.js
+++ b/src/lib/cli/config.js
@@ -21,6 +21,8 @@ export const defaultConfig = {
   concurrentFiles: 1,
   noConfig: false,
   htmlTemplateOptions: {
+    autoHeightSource: true,
+    showMeterBar: false
   }
 };
 

--- a/src/lib/cli/config.js
+++ b/src/lib/cli/config.js
@@ -1,0 +1,157 @@
+import path from 'path';
+import fs from 'fs';
+import parseJSON from 'parse-json';
+import stripJSONComments from 'strip-json-comments';
+
+export class UsageError {
+  constructor(message) {
+    this.message = message;
+  }
+}
+
+const toArray = value => Array.isArray(value) ? value : [value];
+
+export const defaultConfig = {
+  type: ['text'],
+  flowCommandPath: 'flow',
+  projectDir: path.resolve(process.cwd()),
+  excludeGlob: ['node_modules/**'],
+  threshold: 80,
+  outputDir: './flow-coverage',
+  concurrentFiles: 1,
+  noConfig: false
+};
+
+const getProjectDir = config => ({...defaultConfig, ...config}).projectDir;
+
+/**
+ * try to load configuration parameters from the project dir if the following order:
+ * - do not load any config if --no-config option is specified
+ * - from the package.json "flow-coverage-report" property, if any
+ * - from a .flow-coverage-report.json, if any
+ * - from the --config cli parameter, if any
+ */
+export function loadConfig(args) {
+  // remove any undefined property from the yargs object.
+  for (let key of Object.keys(args)) {
+    if (typeof args[key] === 'undefined') {
+      delete args[key];
+    }
+  }
+
+  if (args.noConfig) {
+    return {
+      ...defaultConfig,
+      ...args
+    };
+  }
+
+  if (args.includeGlob) {
+    args.includeGlob = toArray(args.includeGlob);
+  }
+
+  if (args.config) {
+    let filePath = path.resolve(args.config);
+    let fileRawData = fs.readFileSync(filePath);
+    let fileConfigData = parseJSON(stripJSONComments(`${fileRawData}`));
+
+    if (process.env.VERBOSE) {
+      console.log('Loaded config from file', filePath, fileConfigData);
+    }
+
+    return {
+      ...defaultConfig,
+      ...fileConfigData,
+      ...args
+    };
+  }
+
+  let packageJSONPath;
+
+  try {
+    packageJSONPath = path.resolve(path.join(getProjectDir(args), 'package.json'));
+    let pkg = require(packageJSONPath);
+    if (pkg['flow-coverage-report']) {
+      if (process.env.VERBOSE) {
+        console.log('Loaded config from package.json', pkg['flow-coverage-report']);
+      }
+
+      return {
+        ...defaultConfig,
+        ...pkg['flow-coverage-report'],
+        ...args
+      };
+    }
+  } catch (err) {
+    if (process.env.VERBOSE) {
+      console.error('Unable to load config from project package.json', packageJSONPath, err);
+    }
+  }
+
+  let projectConfigPath;
+
+  try {
+    projectConfigPath = path.resolve(path.join(getProjectDir(args), '.flow-coverage-report.json'));
+    let projectConfigRaw = fs.readFileSync(projectConfigPath);
+    let projectConfigData = parseJSON(stripJSONComments(`${projectConfigRaw}`));
+
+    if (process.env.VERBOSE) {
+      console.log('Loaded config from project dir', projectConfigPath, projectConfigData);
+    }
+
+    return {
+      ...defaultConfig,
+      ...projectConfigData,
+      ...args
+    };
+  } catch (err) {
+    if (process.env.VERBOSE) {
+      console.error('Unable to load config from file', projectConfigPath, err);
+    }
+  }
+
+  return {
+    ...defaultConfig,
+    ...args
+  };
+}
+
+/**
+ * Validate the arguments collected from the command line and config files and
+ * ensure that it is a valid FlowCoverageReportOptions object (as described by its
+ * flow type declaration in the "src/lib/index.js module")
+ */
+
+export function validateConfig(args) {
+  function raiseErrorIfArray(value, msg) {
+    if (Array.isArray(value)) {
+      throw new UsageError(`ERROR: Only one ${msg} can be specified.`);
+    }
+  }
+
+  const preventDuplicatedOptions = {
+    projectDir: 'project dir',
+    outputDir: 'output dir',
+    threshold: 'threshold',
+    flowCommandPath: 'flow command',
+    concurrentFiles: '--concurrent-files option'
+  };
+
+  for (const option of Object.keys(preventDuplicatedOptions)) {
+    const msg = preventDuplicatedOptions[option];
+    raiseErrorIfArray(args[option], msg);
+  }
+
+  const {includeGlob} = args;
+  if (!includeGlob || includeGlob.length === 0 || !includeGlob[0]) {
+    throw new UsageError('ERROR: No glob has been specified.');
+  }
+
+  for (const glob of includeGlob) {
+    if (glob[0] === '!') {
+      throw new UsageError('ERROR: Only include glob syntax are supported.');
+    }
+  }
+
+  return args;
+}

--- a/src/lib/cli/config.js
+++ b/src/lib/cli/config.js
@@ -19,7 +19,9 @@ export const defaultConfig = {
   threshold: 80,
   outputDir: './flow-coverage',
   concurrentFiles: 1,
-  noConfig: false
+  noConfig: false,
+  htmlTemplateOptions: {
+  }
 };
 
 const getProjectDir = config => ({...defaultConfig, ...config}).projectDir;

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -25,7 +25,8 @@ exports.run = () => {
     outputDir: args.outputDir,
     projectDir: args.projectDir,
     reportTypes: args.type,
-    threshold: args.threshold
+    threshold: args.threshold,
+    htmlTemplateOptions: args.htmlTemplateOptions
   }).catch(err => {
     console.error('Error while generating Flow Coverage Report: ' + err + ' ' + err.stack);
     process.exit(255); // eslint-disable-line xo/no-process-exit

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -1,8 +1,21 @@
 import {generateFlowCoverageReport} from '../../lib';
 import {processArgv} from './args';
+import {loadConfig, validateConfig, UsageError} from './config';
 
 exports.run = () => {
-  const args = processArgv(process.argv);
+  let args = processArgv(process.argv);
+
+  try {
+    args = loadConfig(args);
+    validateConfig(args);
+  } catch (err) {
+    if (err instanceof UsageError) {
+      console.error('Configuration error:', err.message);
+    } else {
+      console.error('Unexpected exception: ' + err + ' ' + err.stack);
+    }
+    process.exit(255); // eslint-disable-line xo/no-process-exit
+  }
 
   generateFlowCoverageReport({
     concurrentFiles: args.concurrentFiles,

--- a/src/lib/components/body-coverage-sourcefile.jsx
+++ b/src/lib/components/body-coverage-sourcefile.jsx
@@ -72,15 +72,22 @@ module.exports = function HTMLReportBodySourceFile(props: FlowCoverageReportProp
 
   const {summaryRelLink} = props;
 
+  let meterBar;
+
+  if (props.htmlTemplateOptions && props.htmlTemplateOptions.showMeterBar) {
+    meterBar = <FlowCoverageMeterBar percent={percent} threshold={props.threshold}/>;
+  }
+
   return (
     <body>
       <div className="ui grid container">
         <div className="row">
-          <h1 className="twelve wide column">Flow Coverage Report - {fileName}</h1>
-          <div className="four wide column" style={{height: 32}}>
-            <a href={summaryRelLink} id="link-to-summary">
-              Go back to all files summary.
-            </a>
+          <div className="twelve wide column">
+            <h2 className="ui header">
+              <a href={summaryRelLink} id="link-to-summary">
+                Flow Coverage Report
+              </a>
+            </h2>
           </div>
         </div>
         <div className="row">
@@ -106,7 +113,9 @@ module.exports = function HTMLReportBodySourceFile(props: FlowCoverageReportProp
             </tbody>
           </table>
         </div>
-        <FlowCoverageMeterBar percent={percent} threshold={props.threshold}/>
+        {
+          meterBar
+        }
         <div className="row ui one column centered grid">
           <div className="column" style={{textAlign: 'left'}}>
             <div className="row">

--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -53,17 +53,27 @@ module.exports = function HTMLReportBodySummary(props: FlowCoverageReportProps) 
     </table>
   );
 
+  let meterBar;
+
+  if (props.htmlTemplateOptions && props.htmlTemplateOptions.showMeterBar) {
+    meterBar = <FlowCoverageMeterBar percent={percent} threshold={props.threshold}/>;
+  }
+
   return (
     <body>
       <div className="ui grid container">
         <div className="row">
-          <h1>Flow Coverage Report - Summary</h1>
+          <h2>Flow Coverage Report</h2>
         </div>
         <div className="row">
+          <h4 className="ui header">Summary</h4>
           <FlowCoverageSummaryTable {...props}/>
         </div>
-        <FlowCoverageMeterBar percent={percent} threshold={props.threshold}/>
+        {
+          meterBar
+        }
         <div className="row">
+          <h4 className="ui header">Files</h4>
           {filesSummaryTable}
         </div>
         <div className="row centered">

--- a/src/lib/components/head.jsx
+++ b/src/lib/components/head.jsx
@@ -6,19 +6,37 @@ import React from 'react';
 
 import type {FlowCoverageReportProps} from './html-report-page';
 
+const AUTO_HEIGHT_SOURCE = `
+.ui .CodeMirror {
+  border: 1px solid rgba(34,36,38,.15);
+  height: auto;
+}
+`;
+
 module.exports = function HTMLReportHead(props: FlowCoverageReportProps) {
-  var links = !props.assets || !props.assets.css ? [] :
+  const links = !props.assets || !props.assets.css ? [] :
     props.assets.css.map(
       css => <link key={css} rel="stylesheet" href={css}/>
     );
-  var scripts = !props.assets || !props.assets.js ? [] :
+  const scripts = !props.assets || !props.assets.js ? [] :
     props.assets.js.map(
       js => <script key={js} src={js}/>
     );
-  var charset = <meta key="charset" charSet="utf-8"/>;
+
+  let customStyle;
+
+  if (props.htmlTemplateOptions && props.htmlTemplateOptions.autoHeightSource) {
+    customStyle = (
+      <style key="custom-style">
+        {AUTO_HEIGHT_SOURCE}
+      </style>
+    );
+  }
+
+  const charset = <meta key="charset" charSet="utf-8"/>;
   return (
     <head>
-     {[charset].concat(links, scripts)}
+     {[charset].concat(links, scripts, customStyle)}
     </head>
   );
 };

--- a/src/lib/components/html-report-page.jsx
+++ b/src/lib/components/html-report-page.jsx
@@ -30,7 +30,8 @@ export type FlowCoverageReportProps = {
   fileName?: string,
   fileContent?: string|Buffer,
   summaryRelLink?: string,
-  threshold?: number
+  threshold?: number,
+  htmlTemplateOptions?: Object,
 };
 
 module.exports = function HTMLReportPage(props: FlowCoverageReportProps) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -22,6 +22,7 @@ export type FlowCoverageReportOptions = {
   globExcludePatterns: Array<string>,
   outputDir: string,
   reportTypes?: Array<FlowCoverageReportType>,
+  htmlTemplateOptions?: Object,
   threshold?: number,
   concurrentFiles?: number,
   log: Function

--- a/src/lib/report-html.js
+++ b/src/lib/report-html.js
@@ -92,6 +92,7 @@ function renderHTMLReport(opt/* : Object */) {
       reportFileContent = '<!DOCTYPE html>\n' +
         // $FLOW_FIXME: incompatible type with React$Element
         react.renderToStaticMarkup(new FlowCoverageHTMLReport({
+          htmlTemplateOptions: opt.htmlTemplateOptions,
           reportType: opt.type,
           coverageGeneratedAt: opt.coverageGeneratedAt,
           coverageSummaryData: opt.data,
@@ -127,6 +128,7 @@ function renderHTMLReport(opt/* : Object */) {
           var reportFileContent = '<!DOCTYPE html>\n' +
                 // $FLOW_FIXME: incompatible type with React$Element
                 react.renderToStaticMarkup(new FlowCoverageHTMLReport({
+                  htmlTemplateOptions: opt.htmlTemplateOptions,
                   reportType: opt.type,
                   coverageGeneratedAt: opt.coverageGeneratedAt,
                   coverageData: opt.data,
@@ -198,6 +200,7 @@ function generateFlowCoverageReportHTML(
   var coverageGeneratedAt = coverageSummaryData.generatedAt;
   var generateSummary = renderHTMLReport({
     type: 'summary', filename: null,
+    htmlTemplateOptions: opts.htmlTemplateOptions,
     coverageGeneratedAt, projectDir, data: coverageSummaryData, outputDir
   });
 
@@ -211,6 +214,7 @@ function generateFlowCoverageReportHTML(
           var data = coverageSummaryData.files[filename];
           return renderHTMLReport({
             type: 'sourcefile', coverageGeneratedAt,
+            htmlTemplateOptions: opts.htmlTemplateOptions,
             projectDir, filename, data, outputDir
           });
         });


### PR DESCRIPTION
The goal of this PR is to reduce the number of command line options needed in the daily usage of the command line tool, and it introduces the following additional behaviors:

- if the --no-config option has been specified, do not load any external config file
- if a --config option has been specified, load a config file
- try to load additional configuration from a package.json file in the project dir (using the "flow-coverage-report" property)
- try to load additional configuration from a ".flow-coverage-report.json" file in the project dir

This PR contains also the remaining changes on the HTML report from #9, provided as the new defaults of the new `htmlTemplateOptions` config, the old behavior can be restored using the following configuration:

```
{
    "htmlTemplateOptions": {
       "autoHeightSource": false,
       "showMeterBar": true
     }
}
```