### PR TITLE
fix: Fixed missing error exit code with text reporter

### DIFF
--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -128,10 +128,12 @@ function renderTextReport(
   });
 
   const waitForDrain = new Promise(resolve => {
-    if (opts.log) {
+    process.stdout.once('drain', resolve);
+
+    const flushed = process.stdout.write('');
+
+    if (flushed || opts.log) {
       resolve();
-    } else {
-      process.stdout.on('drain', resolve);
     }
   });
 


### PR DESCRIPTION
This PR applies a small change to the `report-text.js` module, so that the text report will wait for the `'drain'` event only if the stdout has not been yet completely drained (or, on the contrary, the module will resolve immediately without waiting for a `'drain'` event that will never be received).

This change should fix #18.