### PR TITLE
fix: Updated flow to 0.38 and fixed the suppress comments

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,11 +2,14 @@
 .*/node_modules/fbjs/.*
 .*/dist/.*
 
+## flow issues on malformed json test fixture
+.*/node_modules/conventional-changelog-core/.*
+
 [include]
 src/.*
 
 [libs]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FLOW_FIXME
-suppress_comment= \\(.\\|\n\\)*\\$FLOW_IGNORE
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
+suppress_comment= \\(.\\|\n\\)*\\$FlowIgnoreMe

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-config-xo-react": "0.9.0",
     "eslint-plugin-flowtype": "2.11.0",
     "eslint-plugin-react": "6.1.2",
-    "flow-bin": "0.33.0",
+    "flow-bin": "0.38.0",
     "mock-require": "1.3.0",
     "nyc": "8.0.0",
     "react-addons-test-utils": "15.3.1",

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -84,7 +84,6 @@ async function checkFlowStatus(
                          {cwd: projectDir, maxBuffer: Infinity},
                          {dontReject: true});
 
-  // $FLOW_FIXME: code is there, but flow doesn't seem to know about it.
   if (res.err && res.err.code !== 2) {
     if (process.env.VERBOSE) {
       console.error('Flow status error', res.err, res.stderr, res.stdout);

--- a/src/lib/report-html.js
+++ b/src/lib/report-html.js
@@ -6,6 +6,7 @@ import type {FlowCoverageSummaryData} from './flow';
 import type {FlowCoverageReportOptions} from './index';
 
 var path = require('path');
+var React = require('react');
 var react = require('react-dom/server');
 var mkdirp = require('./promisified').mkdirp;
 var readFile = require('./promisified').readFile;
@@ -90,8 +91,7 @@ function renderHTMLReport(opt/* : Object */) {
       reportFilePath = path.join(opt.outputDir, 'index.html');
 
       reportFileContent = '<!DOCTYPE html>\n' +
-        // $FLOW_FIXME: incompatible type with React$Element
-        react.renderToStaticMarkup(new FlowCoverageHTMLReport({
+        react.renderToStaticMarkup(React.createElement(FlowCoverageHTMLReport, {
           htmlTemplateOptions: opt.htmlTemplateOptions,
           reportType: opt.type,
           coverageGeneratedAt: opt.coverageGeneratedAt,
@@ -126,8 +126,7 @@ function renderHTMLReport(opt/* : Object */) {
       return mkdirp(path.join(opt.outputDir, 'sourcefiles', dirName)).then(function () {
         return readFile(srcPath).then(function (buff) {
           var reportFileContent = '<!DOCTYPE html>\n' +
-                // $FLOW_FIXME: incompatible type with React$Element
-                react.renderToStaticMarkup(new FlowCoverageHTMLReport({
+                react.renderToStaticMarkup(React.createElement(FlowCoverageHTMLReport, {
                   htmlTemplateOptions: opt.htmlTemplateOptions,
                   reportType: opt.type,
                   coverageGeneratedAt: opt.coverageGeneratedAt,


### PR DESCRIPTION
This PR updates flow-bin to 0.38.0 and fixes some flow validation errors and removes the related suppress comments (which fix #24).