### PR TITLE
feat: Report the @flow annotation/pragma

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "array.prototype.find": "2.0.3",
     "babel-runtime": "6.22.0",
+    "flow-annotation-check": "1.1.2",
     "glob": "7.1.1",
     "minimatch": "3.0.3",
     "mkdirp": "0.5.1",

--- a/src/lib/components/body-coverage-sourcefile.jsx
+++ b/src/lib/components/body-coverage-sourcefile.jsx
@@ -100,6 +100,7 @@ export default function HTMLReportBodySourceFile(props: FlowCoverageReportProps)
                 {...{
                   disableLink: true,
                   filename: fileName,
+                  annotation: coverageData.annotation,
                   flowCoverageParsingError: coverageData.flowCoverageParsingError,
                   flowCoverageError: coverageData.flowCoverageError,
                   flowCoverageException: coverageData.flowCoverageException,

--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -42,6 +42,7 @@ export default function HTMLReportBodySummary(props: FlowCoverageReportProps) {
               flowCoverageException: fileSummary.flowCoverageException,
               flowCoverageStderr: fileSummary.flowCoverageStderr,
 
+              annotation: fileSummary.annotation,
               percent: fileSummary.percent,
               /* eslint-disable camelcase */
               covered_count: fileSummary.expressions.covered_count,

--- a/src/lib/components/coverage-file-table-head.jsx
+++ b/src/lib/components/coverage-file-table-head.jsx
@@ -9,6 +9,7 @@ export default function FlowCoverageFileTableHead() {
     <thead>
       <tr>
         <th key="filename" className="sorted ascending">Filename</th>
+        <th key="annotation">Annotation</th>
         <th key="percent">Percent</th>
         <th key="total">Total</th>
         <th key="covered">Covered</th>

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -12,27 +12,36 @@ function LinkToSourceFileReport(props: {targetFilename: string}) {
 
 export default function FlowCoverageFileTableRow(
   props: {
-    filename: string, covered_count: number, uncovered_count: number,
-    percent: number, disableLink?: boolean, threshold?: number,
-    isError: boolean, flowCoverageError?: ?string, flowCoverageParsingError?: ?string,
-    flowCoverageException?: ?string, flowCoverageStderr?: ?string|?Buffer,
+    filename: string,
+    annotation: string,
+    covered_count: number,
+    uncovered_count: number,
+    percent: number,
+    disableLink?: boolean,
+    threshold?: number,
+    isError: boolean,
+    flowCoverageError?: ?string,
+    flowCoverageParsingError?: ?string,
+    flowCoverageException?: ?string,
+    flowCoverageStderr?: ?string|?Buffer,
   }
 ) {
   /* eslint-disable camelcase */
   const {
     filename,
+    annotation,
     covered_count, uncovered_count,
-    percent, isError
+    percent, isError,
+    disableLink
   } = props;
 
-  let {
-    disableLink, threshold
-  } = props;
+  const threshold = props.threshold || 80;
 
-  disableLink = props.disableLink;
-  threshold = props.threshold || 80;
-
-  let className = percent >= threshold ? 'positive' : 'negative';
+  const isFlow = annotation === 'flow';
+  const aboveThreshold = percent >= threshold;
+  let className = (!isError && isFlow && aboveThreshold) ?
+    'positive' :
+    'negative';
 
   let errorPopup;
 
@@ -74,6 +83,7 @@ export default function FlowCoverageFileTableRow(
       <td key="filename" className={disableLink ? '' : 'selectable'}>
         {disableLink ? filename : <LinkToSourceFileReport targetFilename={filename}/>}
       </td>
+      <td key="annotation"> @{annotation} </td>
       <td key="percent" className={isError && 'error'}>
         {
           isError ?

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -19,25 +19,36 @@ function renderTextReport(
     rightPadding: 1,
     borderStyle: 2
   });
-  filesTable.push(['filename', 'percent', 'total', 'covered', 'uncovered']);
+  filesTable.push([
+    'filename',
+    'annotation',
+    'percent',
+    'total',
+    'covered',
+    'uncovered'
+  ]);
 
   let row = 0;
   for (const filename of Object.keys(coverageData.files).sort()) {
     row += 1;
     const data = coverageData.files[filename];
 
+    const annotation = data.annotation || 'no flow';
     const covered = data.expressions.covered_count;
     const uncovered = data.expressions.uncovered_count;
-    let percent = data.percent || NaN;
+    const percent = data.percent || NaN;
 
     filesTable.push([
       filename,
+      annotation,
       data.isError ? '\u26A0 Error' : percent + ' %',
-      covered + uncovered, covered, uncovered
+      covered + uncovered,
+      covered,
+      uncovered
     ]);
 
     let rowColor;
-    if (percent >= (opts.threshold || 80)) {
+    if (annotation === 'flow' && percent >= (opts.threshold || 80)) {
       rowColor = 'green';
     } else {
       rowColor = 'red';

--- a/src/test/unit/test-react-components/test-coverage-file-table-head.js
+++ b/src/test/unit/test-react-components/test-coverage-file-table-head.js
@@ -16,7 +16,7 @@ test('<FlowCoverageFileTableHead />', t => {
   const wrapper = shallow(<FlowCoverageFileTableHead/>);
 
   const expectedKeys = [
-    'filename', 'percent', 'total', 'covered', 'uncovered'
+    'filename', 'annotation', 'percent', 'total', 'covered', 'uncovered'
   ];
 
   t.is(wrapper.find('thead').length, 1);

--- a/src/test/unit/test-react-components/test-coverage-file-table-row.js
+++ b/src/test/unit/test-react-components/test-coverage-file-table-row.js
@@ -16,6 +16,7 @@ test('<FlowCoverageFileTableRow />', t => {
   const props = {
     /* eslint-disable camelcase */
     filename: 'fake-filename.js',
+    annotation: 'flow',
     covered_count: 1,
     uncovered_count: 2,
     disableLink: false
@@ -24,7 +25,7 @@ test('<FlowCoverageFileTableRow />', t => {
   const wrapper = shallow(<FlowCoverageFileTableRow {...props}/>);
 
   const expectedKeys = [
-    'filename', 'percent', 'total', 'covered', 'uncovered'
+    'filename', 'annotation', 'percent', 'total', 'covered', 'uncovered'
   ];
 
   t.is(wrapper.find('tr').length, 1);
@@ -43,6 +44,7 @@ test('<FlowCoverageFileTableRow /> with errors', t => {
   const FlowCoverageFileTableRow = require(REACT_COMPONENT).default;
   const baseErrorProps = {
     filename: 'fake-filename.js',
+    annotation: 'no flow',
     disableLink: true,
     isError: true,
 
@@ -56,7 +58,7 @@ test('<FlowCoverageFileTableRow /> with errors', t => {
     let wrapper = shallow(<FlowCoverageFileTableRow {...props}/>);
 
     const expectedKeys = [
-      'filename', 'percent', 'total', 'covered', 'uncovered'
+      'filename', 'annotation', 'percent', 'total', 'covered', 'uncovered'
     ];
 
     t.is(wrapper.find('tr').length, 1);


### PR DESCRIPTION
This is to address #12 

We're pulling in whatever the file annotation `flow-annotation-check` says so we can print it along with the lines-covered information in all three reporters.

It's important that files have the pragma so flow will complain if there are errors within. Without the pragma flow will not return errors inside those files (unless the [`all` option](https://flowtype.org/docs/advanced-configuration.html#options) is specified in your config). 

I haven't made it exit with a different status if the pragma is missing, but that's something we could do behind a cli flag to preserve backwards compatibility. Also we could have another flag to make it skip processing the ast which would speed things up again for codebases that use the flow `all` config option. Any thoughts on these two?

