### PR TITLE
Fix bug – ignoring custom threshold in html report

### DIFF
--- a/src/lib/components/coverage-summary-table.jsx
+++ b/src/lib/components/coverage-summary-table.jsx
@@ -12,7 +12,7 @@ export default function FlowCoverageSummaryTable(props: FlowCoverageReportProps)
   }
   var summary = props.coverageSummaryData;
   var percent = summary.percent || NaN;
-  var threshold = props.threshold || 80;
+  var threshold = summary.threshold || 80;
   var className = percent >= threshold ? 'positive' : 'negative';
 
   return (


### PR DESCRIPTION
Actual threshold value stored in `props.coverageSummaryData`,
not in `props` itself. This caused html report to render always 
using default threshold level of 80 and ignore threshold configuration
parameter.