### PR TITLE
fix: escape file special chars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: node_js
 sudo: false
 
 node_js:
-- '4'
 - '6'
 
 os:
 - linux
-- osx
+
+## Disable because it seems to be often slow (and sometimes errored)
+## on Travis CI
+# - osx
 
 matrix:
   fast_finish: true

--- a/__tests__/common.js
+++ b/__tests__/common.js
@@ -4,6 +4,10 @@ import {exec} from 'child_process';
 export const FIXTURE_PATH = path.join(__dirname, 'fixtures');
 export const BIN_PATH = path.join(__dirname, '../bin/');
 
+// Increased timeout for integrations tests (which can be slower on
+// older nodejs version or because of the flow daemon).
+jest.setTimeout(20000);
+
 export function runFlowCoverageReport(args, options = {}) {
   return new Promise(resolve => {
     options.env = options.env || {};

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a space.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a space.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a-"-char.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a-"-char.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a-$-char.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a-$-char.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a-'-char.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a-'-char.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a-\-char.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a-\-char.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/fixtures/file-special-chars-escape/src/file-with-a-`-char.js
+++ b/__tests__/fixtures/file-special-chars-escape/src/file-with-a-`-char.js
@@ -1,0 +1,5 @@
+// @flow
+
+const data: string = "exported value";
+
+export default data;

--- a/__tests__/integrations/cli/__snapshots__/test-file-special-chars-escape.js.snap
+++ b/__tests__/integrations/cli/__snapshots__/test-file-special-chars-escape.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fixed #92 - Escape special chars in filenames 1`] = `
+Object {
+  "filteredStdout": Array [
+    "│ src/file-with-a space.js  │       flow │   100 % │     3 │       3 │ 0         │",
+    "│ src/file-with-a-\\"-char.js │       flow │   100 % │     3 │       3 │ 0         │",
+    "│ src/file-with-a-$-char.js │       flow │   100 % │     3 │       3 │ 0         │",
+    "│ src/file-with-a-'-char.js │       flow │   100 % │     3 │       3 │ 0         │",
+    "│ src/file-with-a-\\\\-char.js │       flow │   100 % │     3 │       3 │ 0         │",
+    "│ src/file-with-a-\`-char.js │       flow │   100 % │     3 │       3 │ 0         │",
+  ],
+  "stderr": "",
+}
+`;

--- a/__tests__/integrations/cli/test-file-special-chars-escape.js
+++ b/__tests__/integrations/cli/test-file-special-chars-escape.js
@@ -1,0 +1,24 @@
+'use babel';
+
+import path from 'path';
+
+import {
+  FIXTURE_PATH,
+  runFlowCoverageReport
+} from '../../common';
+
+const testProjectDir = path.join(FIXTURE_PATH, 'file-special-chars-escape');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // 10 second timeout
+
+test('Fixed #92 - Escape special chars in filenames', async () => {
+  const {stdout, stderr} = await runFlowCoverageReport([
+    '-i', `"src/*.js"`
+  ], {cwd: testProjectDir});
+
+  const filteredStdout = stdout.split('\n').filter(
+    line => line.indexOf('src/file-with-a') >= 0
+  );
+
+  expect({filteredStdout, stderr}).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-plugin-jest": "20.0.2",
     "eslint-plugin-react": "7.1.0",
     "flow-bin": "0.46.0",
-    "jest": "20.0.3",
+    "jest": "21.2.1",
     "react-test-renderer": "15.5.4",
     "xo": "0.18.1"
   },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
-    "flow-annotation-check": "1.3.0",
+    "flow-annotation-check": "1.3.1",
     "glob": "7.1.1",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",

--- a/src/__tests__/test-promisified-exec.js
+++ b/src/__tests__/test-promisified-exec.js
@@ -51,7 +51,7 @@ test('promisified exec throws', async () => {
   } catch (err) {
     exception = err;
   }
-  expect(exception).toMatchObject({message: mockErrorMessage});
+  expect({message: exception.message}).toMatchObject({message: mockErrorMessage});
 });
 
 test('promisified exec doNotReject', async () => {

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -13,6 +13,11 @@ if (!Array.prototype.find) {
   require('array.prototype.find').shim();
 }
 
+// Escape special characters in file names.
+export function escapeFileName(fileName: string): string {
+  return fileName.replace(/(["\s'$`\\])/g, '\\$1');
+}
+
 /* eslint-disable camelcase */
 export function getCoveredPercent(
   {
@@ -175,7 +180,7 @@ export async function collectFlowCoverageForFile(
   }
 
   const res = await exec(
-    `${flowCommandPath} coverage --json ${filename}`,
+    `${flowCommandPath} coverage --json ${escapeFileName(filename)}`,
     // NOTE: set a default timeouts and maxButter to Infinity to prevent,
     // misconfigured projects and source files that should raises errors
     // or hangs the flow daemon to prevent the coverage reporter to complete


### PR DESCRIPTION
This PR contains some fixes needed to handle files with special characters correctly (#92):

- escape special characters file names in "flow coverage" commands (with the same regular expression used in the `flow-annotation-checks` dependency to fix the same issue).
- update flow-annotation-checks dependencies (which contains the fix for the "extract flow annotation" phase).
- added an additional integration test that execute `flow-coverage-report` on a fake project with special characters in the file names.

Thanks to @ryan953 for tracking down the issue and for fixing for it. 