### PR TITLE
No annotation, no coverage

### DIFF
--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -7,6 +7,8 @@ import temp from 'temp';
 import {genCheckFlowStatus} from 'flow-annotation-check';
 import {exec, glob, writeFile} from './promisified';
 
+const NO_ANNOTATION_NO_COVERAGE = true; // TODO(dmnd): option or default?
+
 // Load the Array.prototype.find polyfill if needed (e.g. nodejs 0.12).
 /* istanbul ignore if  */
 if (!Array.prototype.find) {
@@ -237,6 +239,12 @@ export async function collectFlowCoverageForFile(
   if (parsedData && !parsedData.error) {
     parsedData.filename = filename;
     parsedData.annotation = await genCheckFlowStatus(flowCommandPath, filename);
+
+    if (parsedData.annotation === 'no flow' && NO_ANNOTATION_NO_COVERAGE) {
+      parsedData.expressions.uncovered_count += parsedData.expressions.covered_count;
+      parsedData.expressions.covered_count = 0;
+    }
+
     return parsedData;
   }
 


### PR DESCRIPTION
When calculating coverage for a project, I don't care about coverage in
files that don't have the `@flow` pragma. While it's nice that Flow
infers types anyway, since it's never going to report an error it
doesn't help me at all and is potentially misleading. For example, my
project is 75% covered with master, but only 34% covered with this
change.

This PR changes flow-coverage-report to ignore coverage in unannotated
files. This could be considered a breaking change or a bugfix - I'm not
sure. You might consider making this a configuration option.

Resolves #85