### PR TITLE
Filenames can't have spaces in them

### DIFF
--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -382,7 +382,7 @@ export function collectFlowCoverage(
             }
 
             waitForCollectedDataFromFiles.push(collectFlowCoverageForFile(
-              flowCommandPath, flowCommandTimeout, projectDir, filename, tmpDirPath
+              flowCommandPath, flowCommandTimeout, projectDir, `"${filename}"`, tmpDirPath
             ).then(data => {
               /* eslint-disable camelcase */
               coverageSummaryData.covered_count += data.expressions.covered_count;


### PR DESCRIPTION
If your source filenames have spaces in them, flow-coverage-report would error out.

I simply wrapped the filenames in a pair of quotes before they're passed to flow.

Let me know if there's anything wrong here.

Thanks for all your hard work!