### PR TITLE
Upgrade to a newer Flow, and make it happy (Closes #87)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-flowtype": "2.33.0",
     "eslint-plugin-jest": "20.0.2",
     "eslint-plugin-react": "7.1.0",
-    "flow-bin": "0.46.0",
+    "flow-bin": "0.54.1",
     "jest": "20.0.3",
     "react-test-renderer": "15.5.4",
     "xo": "0.18.1"

--- a/src/lib/report-html.js
+++ b/src/lib/report-html.js
@@ -61,7 +61,7 @@ function copyAssets(outputDir/* : string */) {
   return Promise.all(assetsList.map(copyAsset.bind(null, outputDir)));
 }
 
-function renderHTMLReport(opt/* : Object */) {
+function renderHTMLReport(opt/* : Object */)/* : Promise<*> */ {
   if (opt.filename &&
       opt.filename.indexOf('..') >= 0) {
     return Promise.reject(new Error(


### PR DESCRIPTION
While working on another project, I noticed Flow was choking on this.

The issue is that `Promise.reject` returns a parametrized Promise, but Flow can't know which parameter to use directly because the call to `Promise.reject` itself has nothing about it. The solution is to type the return value of the function. I use the `*` to let Flow infer the parameter by itself, but if you think I should use `void` which is the actual type I can do it.