### PR TITLE
Add a badge reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
+    "badge-up": "2.3.0",
     "flow-annotation-check": "1.3.1",
     "glob": "7.1.1",
     "minimatch": "3.0.4",

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -38,7 +38,7 @@ export default function processArgv(argv) {
     .option('type', {
       alias: 't',
       type: 'choice',
-      choices: ['html', 'json', 'text'],
+      choices: ['html', 'json', 'text', 'badge'],
       describe: `format of the generated reports (defaults to "${defaultConfig.type.join(', ')}")`
     })
     // --project-dir "/project/dir/path"

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,12 +7,13 @@ import path from 'path';
 import {collectFlowCoverage} from './flow';
 import {withTmpDir} from './promisified';
 import reportHTML from './report-html';
+import reportBadge from './report-badge';
 import reportJSON from './report-json';
 import reportText from './report-text';
 
 import type {FlowCoverageSummaryData} from './flow'; // eslint-disable-line no-duplicate-imports
 
-export type FlowCoverageReportType = 'json' | 'text' | 'html';
+export type FlowCoverageReportType = 'json' | 'text' | 'badge' |'html';
 
 export type FlowCoverageReportOptions = {
   projectDir: string,
@@ -92,6 +93,10 @@ export default async function generateFlowCoverageReport(opts: FlowCoverageRepor
 
   if (reportTypes.indexOf('text') >= 0) {
     reportResults.push(reportText.generate(coverageData, opts));
+  }
+
+  if (reportTypes.indexOf('badge') >= 0) {
+    reportResults.push(reportBadge.generate(coverageData, opts));
   }
 
   if (reportTypes.indexOf('html') >= 0) {

--- a/src/lib/report-badge.js
+++ b/src/lib/report-badge.js
@@ -1,0 +1,58 @@
+'use strict';
+
+// @flow
+
+import path from 'path';
+
+import badge from 'badge-up';
+
+import {mkdirp, writeFile} from './promisified';
+
+import type {FlowCoverageSummaryData} from './flow';
+import type {FlowCoverageReportOptions} from './index';
+
+function saveBadgeReport(
+  coverageData: FlowCoverageSummaryData,
+  opts: FlowCoverageReportOptions
+): Promise<void> {
+  const percent = coverageData.percent;
+  const threshold = opts.threshold || 80;
+  const difference = percent - threshold;
+
+  let color;
+
+  if (difference < -40) {
+    color = 'red';
+  } else if (difference < -30) {
+    color = 'orange';
+  } else if (difference < -20) {
+    color = 'yellow';
+  } else if (difference < -10) {
+    color = 'yellowgreen';
+  } else if (difference < 0) {
+    color = 'green';
+  } else {
+    color = 'brightgreen';
+  }
+
+  const badgeGen = () => new Promise((resolve, reject) => {
+    badge('flow', `${percent}%`, badge.colors[color], (err, svg) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(svg);
+      }
+    });
+  });
+
+  const projectDir = opts.projectDir;
+  const outputDir = opts.outputDir || path.join(projectDir, 'flow-coverage');
+
+  return mkdirp(outputDir).then(badgeGen).then(svg => {
+    return writeFile(path.join(outputDir, 'flow-coverage.svg'), svg);
+  });
+}
+
+export default {
+  generate: saveBadgeReport
+};


### PR DESCRIPTION
I don’t expect this to be merged, It is only a POC for creating a badge that could go well with the HTML report (#129). A better way of implementing this—in my opinion—would be to create the badge in the HTML reporter, as opposed to a separate reporter.
