### PR TITLE
feat: Implement a new --strict-coverage option to enforce a more strict coverage reporting mode

### DIFF
--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -75,6 +75,12 @@ export default function processArgv(argv) {
       type: 'number',
       describe: `the maximum number of files concurrently submitted to flow (defaults to ${defaultConfig.concurrentFiles})`
     })
+    // --strict-coverage
+    .option('strict-coverage', {
+      type: 'boolean',
+      describe: 'non annotated and flow weak files are considered as completely uncovered. ' +
+        'Default behavior is for flow to best-guess coverage on all the files included in the report.'
+    })
     // --no-config
     .option('no-config', {
       type: 'boolean',

--- a/src/lib/cli/config.js
+++ b/src/lib/cli/config.js
@@ -19,6 +19,7 @@ export const defaultConfig = {
   threshold: 80,
   outputDir: './flow-coverage',
   concurrentFiles: 1,
+  strictCoverage: false,
   noConfig: false,
   htmlTemplateOptions: {
     autoHeightSource: true,

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -26,6 +26,7 @@ exports.run = () => {
     projectDir: args.projectDir,
     reportTypes: args.type,
     threshold: args.threshold,
+    strictCoverage: args.strictCoverage,
     htmlTemplateOptions: args.htmlTemplateOptions
   }).catch(err => {
     console.error('Error while generating Flow Coverage Report: ' + err + ' ' + err.stack);

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -25,6 +25,7 @@ export type FlowCoverageReportOptions = {
   reportTypes?: Array<FlowCoverageReportType>,
   htmlTemplateOptions?: Object,
   threshold: number,
+  strictCoverage: boolean,
   concurrentFiles?: number,
   log: Function
 };
@@ -81,7 +82,8 @@ export default async function generateFlowCoverageReport(opts: FlowCoverageRepor
     opts.flowCommandPath, opts.flowCommandTimeout,
     opts.projectDir, opts.globIncludePatterns, opts.globExcludePatterns,
     opts.threshold, opts.concurrentFiles || 1,
-    tmpDirPath
+    tmpDirPath,
+    opts.strictCoverage
   );
 
   const reportResults = [];


### PR DESCRIPTION
This PR contains the changes from #102 and #138 (contributed by @dmnd and @uforic) with the following changes applied:

- renamed the new cli option to --strict-coverage
- renamed config file option to strictCoverage
- include strictCoverage option in the JSON summary result
- add a new test case to test the expected behavior in "strict coverage" mode. 
