### PR TITLE
chore: Replace the prepublish script with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jest:integrations": "jest __tests__/integrations -i",
     "jest": "npm run jest:unit && npm run jest:integrations",
     "lint": "xo --reporter=compact",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "cross-env NODE_ENV=test npm run build && npm run lint && npm run flow-check && npm run jest && npm run flow-coverage"
   },
   "keywords": [


### PR DESCRIPTION
The `prepublish` script has been depricated in favor of
`prepare`. `prepublish` doesn’t run before `npm install` in npm v5
which is inconvenient. when pulling straight from the git repository.

See here for details: https://docs.npmjs.com/all#prepublish-and-prepare