### PR TITLE
--exclude-non-flow  to exclude non flow files from coverage report

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,6 +10,7 @@
 src/.*
 
 [libs]
+flow-typed/npm
 
 [options]
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/flow-typed/npm/flow-bin_v0.x.x.js
+++ b/flow-typed/npm/flow-bin_v0.x.x.js
@@ -1,0 +1,6 @@
+// flow-typed signature: 6a5610678d4b01e13bbfbbc62bdaf583
+// flow-typed version: 3817bc6980/flow-bin_v0.x.x/flow_>=v0.25.x
+
+declare module "flow-bin" {
+  declare module.exports: string;
+}

--- a/flow-typed/npm/jest_v22.x.x.js
+++ b/flow-typed/npm/jest_v22.x.x.js
@@ -1,0 +1,594 @@
+// flow-typed signature: 18018da6c1a1d95b4ab1c64bb5fe86ca
+// flow-typed version: c1ad61e7d4/jest_v22.x.x/flow_>=v0.39.x
+
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Deprecated: use jest.fn(() => value) instead
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean
+};
+
+type JestMatcher = (actual: any, expected: any) => JestMatcherResult;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType
+};
+
+/**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBePresent(): void,
+  toContainReact(element: React$Element<any>): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp(propKey: string, propValue?: any): void,
+  toHaveRef(refName: string): void,
+  toHaveState(stateKey: string, stateValue?: any): void,
+  toHaveStyle(styleKey: string, styleValue?: any): void,
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toIncludeText(text: string): void,
+  toHaveValue(value: any): void,
+  toMatchElement(element: React$Element<any>): void,
+  toMatchSelector(selector: string): void
+};
+
+type JestExpectType = {
+  not: JestExpectType & EnzymeMatchersType,
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void,
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toBeCalled(): void,
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void,
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void,
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void,
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void,
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void,
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void,
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void,
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void,
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void,
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void,
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void,
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void,
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void,
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void,
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void,
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void,
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void,
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void,
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void,
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void,
+  /**
+   * This ensures that a React component matches the most recent snapshot.
+   */
+  toMatchSnapshot(name?: string): void,
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | Class<Error> | RegExp): void,
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void,
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void
+};
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Restores all mocks back to their original value.
+   */
+  restoreAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(object: Object, methodName: string): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType
+};
+
+type JestSpyType = {
+  calls: JestCallsType
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: JestTestName, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: JestTestName, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: JestTestName, fn: () => void): void
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Only run this test
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Skip running this test
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+  /**
+   * Run the test concurrently
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void
+};
+declare function fit(
+  name: JestTestName,
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (value: any): JestExpectType & JestPromiseType & EnzymeMatchersType,
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(serializer: (input: Object) => string): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  objectContaining(value: Object): void,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): void,
+  stringMatching(value: string | RegExp): void
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): void,
+  arrayContaining(value: Array<mixed>): void,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): void,
+  stringMatching(value: string): void
+};

--- a/flow-typed/npm/minimatch_v3.x.x.js
+++ b/flow-typed/npm/minimatch_v3.x.x.js
@@ -1,0 +1,53 @@
+// flow-typed signature: bc0af4a44bb8631039f713b1afba6988
+// flow-typed version: d42cbef63c/minimatch_v3.x.x/flow_>=v0.25.x
+
+type $npm$minimatch$Options = {
+  debug?: boolean,
+  nobrace?: boolean,
+  noglobstar?: boolean,
+  dot?: boolean,
+  noext?: boolean,
+  nocase?: boolean,
+  nonull?: boolean,
+  matchBase?: boolean,
+  nocomment?: boolean,
+  nonegate?: boolean,
+  flipNegate?: boolean
+};
+
+declare module "minimatch" {
+  declare class Minimatch {
+    constructor(pattern: string, options?: $npm$minimatch$Options): Minimatch,
+    set: Array<Array<string | RegExp>>,
+    regexp: null | RegExp, // null until .makeRe() is called
+    negate: boolean,
+    comment: boolean,
+    empty: boolean,
+    makeRe(): RegExp | false,
+    match(name: string): boolean,
+    matchOne(
+      fileArray: Array<string>,
+      patternArray: Array<string>,
+      partial?: boolean
+    ): boolean
+  }
+
+  declare class MinimatchModule {
+    Minimatch: Class<Minimatch>,
+
+    (name: string, pattern: string, options?: $npm$minimatch$Options): boolean,
+
+    filter(
+      pattern: string,
+      options?: $npm$minimatch$Options
+    ): (value: string) => boolean,
+
+    match(
+      list: Array<string>,
+      pattern: string,
+      options?: $npm$minimatch$Options
+    ): Array<string>
+  }
+
+  declare module.exports: MinimatchModule;
+}

--- a/flow-typed/npm/mkdirp_v0.5.x.js
+++ b/flow-typed/npm/mkdirp_v0.5.x.js
@@ -1,0 +1,13 @@
+// flow-typed signature: 82aa0feffc2bbd64dce3bec492f5d601
+// flow-typed version: 3315d89a00/mkdirp_v0.5.x/flow_>=v0.25.0
+
+declare module 'mkdirp' {
+  declare type Options = number | { mode?: number; fs?: mixed };
+
+  declare type Callback = (err: ?Error, path: ?string) => void;
+
+  declare module.exports: {
+    (path: string, options?: Options | Callback, callback?: Callback): void;
+    sync(path: string, options?: Options): void;
+  };
+}

--- a/flow-typed/npm/rimraf_v2.x.x.js
+++ b/flow-typed/npm/rimraf_v2.x.x.js
@@ -1,0 +1,18 @@
+// flow-typed signature: 1dff23447d5e18f5ac2b05aaec7cfb74
+// flow-typed version: a453e98ea2/rimraf_v2.x.x/flow_>=v0.25.0
+
+declare module 'rimraf' {
+  declare type Options = {
+	  maxBusyTries?: number,
+	  emfileWait?: number,
+	  glob?: boolean,
+	  disableGlob?: boolean
+  };
+  
+  declare type Callback = (err: ?Error, path: ?string) => void;
+
+  declare module.exports: {
+    (f: string, opts?: Options | Callback, callback?: Callback): void;
+    sync(path: string, opts?: Options): void;
+  };
+}

--- a/flow-typed/npm/strip-json-comments_v2.x.x.js
+++ b/flow-typed/npm/strip-json-comments_v2.x.x.js
@@ -1,0 +1,9 @@
+// flow-typed signature: 355bccb70c51fc8f5126d5130c2ff1de
+// flow-typed version: b43dff3e0e/strip-json-comments_v2.x.x/flow_>=v0.25.x
+
+declare module 'strip-json-comments' {
+  declare module.exports: (
+    input: string,
+    options?: { whitespace: boolean }
+  ) => string;
+}

--- a/flow-typed/npm/tempy_v0.x.x.js
+++ b/flow-typed/npm/tempy_v0.x.x.js
@@ -1,0 +1,15 @@
+// flow-typed signature: 26cb5563f33a7f9d88f78ddf7b33ad0b
+// flow-typed version: 56b4548fe9/tempy_v0.x.x/flow_>=v0.47.x
+
+type $npm$tempy$Options = {
+  extension?: string,
+  name?: string
+};
+
+declare module "tempy" {
+  declare module.exports: {
+    directory: () => string,
+    file: (options?: $npm$tempy$Options) => string,
+    root: string
+  };
+}

--- a/flow-typed/npm/yargs_v8.x.x.js
+++ b/flow-typed/npm/yargs_v8.x.x.js
@@ -1,0 +1,255 @@
+// flow-typed signature: 28b06f0a373cccd37c902772cd2b3a57
+// flow-typed version: da30fe6876/yargs_v8.x.x/flow_>=v0.42.x
+
+declare module "yargs" {
+  declare type Argv = {
+    _: Array<string>,
+    $0: string,
+    [key: string]: any
+  };
+
+  declare type Options = $Shape<{
+    alias: string | Array<string>,
+    array: boolean,
+    boolean: boolean,
+    choices: Array<mixed>,
+    coerce: (arg: any) => mixed,
+    config: boolean,
+    configParser: (configPath: string) => { [key: string]: mixed },
+    conflicts: string | { [key: string]: string },
+    count: boolean,
+    default: mixed,
+    defaultDescription: string,
+    demandOption: boolean | string,
+    desc: string,
+    describe: string,
+    description: string,
+    global: boolean,
+    group: string,
+    implies: string | { [key: string]: string },
+    nargs: number,
+    normalize: boolean,
+    number: boolean,
+    requiresArg: boolean,
+    skipValidation: boolean,
+    string: boolean,
+    type: "array" | "boolean" | "count" | "number" | "string"
+  }>;
+
+  declare type CommonModuleObject = {|
+    command?: string | Array<string>,
+    aliases?: Array<string> | string,
+    builder?: { [key: string]: Options } | ((yargsInstance: Yargs) => mixed),
+    handler?: (argv: Argv) => void
+  |};
+
+  declare type ModuleObjectDesc = {|
+    ...CommonModuleObject,
+    desc?: string | false
+  |};
+
+  declare type ModuleObjectDescribe = {|
+    ...CommonModuleObject,
+    describe?: string | false
+  |};
+
+  declare type ModuleObjectDescription = {|
+    ...CommonModuleObject,
+    description?: string | false
+  |};
+
+  declare type ModuleObject =
+    | ModuleObjectDesc
+    | ModuleObjectDescribe
+    | ModuleObjectDescription;
+
+  declare class Yargs {
+    (args: Array<string>): Yargs;
+
+    alias(key: string, alias: string): this;
+    alias(alias: { [key: string]: string | Array<string> }): this;
+    argv: Argv;
+    array(key: string | Array<string>): this;
+    boolean(paramter: string | Array<string>): this;
+    check(fn: (argv: Argv, options: Array<string>) => ?boolean): this;
+    choices(key: string, allowed: Array<string>): this;
+    choices(allowed: { [key: string]: Array<string> }): this;
+    coerce(key: string, fn: (value: any) => mixed): this;
+    coerce(object: { [key: string]: (value: any) => mixed }): this;
+    coerce(keys: Array<string>, fn: (value: any) => mixed): this;
+
+    command(
+      cmd: string | Array<string>,
+      desc: string | false,
+      builder?: { [key: string]: Options } | ((yargsInstance: Yargs) => mixed),
+      handler?: Function
+    ): this;
+
+    command(
+      cmd: string | Array<string>,
+      desc: string | false,
+      module: ModuleObject
+    ): this;
+
+    command(module: ModuleObject): this;
+
+    completion(
+      cmd: string,
+      description?: string,
+      fn?: (
+        current: string,
+        argv: Argv,
+        done: (competion: Array<string>) => void
+      ) => ?(Array<string> | Promise<Array<string>>)
+    ): this;
+
+    config(
+      key?: string,
+      description?: string,
+      parseFn?: (configPath: string) => { [key: string]: mixed }
+    ): this;
+    config(
+      key: string,
+      parseFn?: (configPath: string) => { [key: string]: mixed }
+    ): this;
+    config(config: { [key: string]: mixed }): this;
+
+    conflicts(keyA: string, keyB: string): this;
+    conflicts(keys: { [key: string]: string }): this;
+
+    count(name: string): this;
+
+    default(key: string, value: mixed, description?: string): this;
+    default(defaults: { [key: string]: mixed }): this;
+
+    // Deprecated: use demandOption() and demandCommand() instead.
+    demand(key: string, msg?: string | boolean): this;
+    demand(count: number, max?: number, msg?: string | boolean): this;
+
+    demandOption(key: string | Array<string>, msg?: string | boolean): this;
+
+    demandCommand(min: number, minMsg?: string): this;
+    demandCommand(
+      min: number,
+      max: number,
+      minMsg?: string,
+      maxMsg?: string
+    ): this;
+
+    describe(key: string, description: string): this;
+    describe(describeObject: { [key: string]: string }): this;
+
+    detectLocale(shouldDetect: boolean): this;
+
+    env(prefix?: string): this;
+
+    epilog(text: string): this;
+    epilogue(text: string): this;
+
+    example(cmd: string, desc: string): this;
+
+    exitProcess(enable: boolean): this;
+
+    fail(fn: (failureMessage: string, err: Error, yargs: Yargs) => mixed): this;
+
+    getCompletion(args: Array<string>, fn: () => void): this;
+
+    global(globals: string | Array<string>, isGlobal?: boolean): this;
+
+    group(key: string | Array<string>, groupName: string): this;
+
+    help(option?: string, desc?: string): this;
+
+    implies(keyA: string, keyB: string): this;
+    implies(keys: { [key: string]: string }): this;
+
+    locale(
+      locale: | "de"
+      | "en"
+      | "es"
+      | "fr"
+      | "hi"
+      | "hu"
+      | "id"
+      | "it"
+      | "ja"
+      | "ko"
+      | "nb"
+      | "pirate"
+      | "pl"
+      | "pt"
+      | "pt_BR"
+      | "ru"
+      | "th"
+      | "tr"
+      | "zh_CN"
+    ): this;
+    locale(): string;
+
+    nargs(key: string, count: number): this;
+
+    normalize(key: string): this;
+
+    number(key: string | Array<string>): this;
+
+    option(key: string, options?: Options): this;
+    option(optionMap: { [key: string]: Options }): this;
+
+    options(key: string, options?: Options): this;
+    options(optionMap: { [key: string]: Options }): this;
+
+    parse(
+      args: string | Array<string>,
+      context?: { [key: string]: mixed },
+      parseCallback?: (err: Error, argv: Argv, output?: string) => void
+    ): Argv;
+    parse(
+      args: string | Array<string>,
+      parseCallback?: (err: Error, argv: Argv, output?: string) => void
+    ): Argv;
+
+    pkgConf(key: string, cwd?: string): this;
+
+    recommendCommands(): this;
+
+    // Alias of demand()
+    require(key: string, msg: string | boolean): this;
+    require(count: number, max?: number, msg?: string | boolean): this;
+
+    requiresArg(key: string | Array<string>): this;
+
+    reset(): this;
+
+    showCompletionScript(): this;
+
+    showHelp(consoleLevel?: "error" | "warn" | "log"): this;
+
+    showHelpOnFail(enable: boolean, message?: string): this;
+
+    strict(): this;
+
+    skipValidation(key: string): this;
+
+    strict(global?: boolean): this;
+
+    string(key: string | Array<string>): this;
+
+    updateLocale(obj: { [key: string]: string }): this;
+    updateStrings(obj: { [key: string]: string }): this;
+
+    usage(message: string, opts?: { [key: string]: Options }): this;
+
+    version(): this;
+    version(version: string): this;
+    version(option: string | (() => string), version: string): this;
+    version(
+      option: string | (() => string),
+      description: string | (() => string),
+      version: string
+    ): this;
+
+    wrap(columns: number | null): this;
+  }
+
+  declare module.exports: Yargs;
+}

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
       "node"
     ],
     "ignores": [
+      "flow-typed/**/*",
       "dist/**/*",
       "assets/**/*",
       "node_modules/**/*",

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -1,3 +1,4 @@
+// @flow
 import path from 'path';
 import yargs from 'yargs';
 
@@ -19,25 +20,24 @@ For more informations:
   https://github.com/rpl/flow-coverage-report
 `;
 
-export default function processArgv(argv) {
+export default function processArgv(argv: Array<string>) {
   const appName = path.basename(argv[1]).split('.')[0];
 
   return yargs(argv).usage('Usage: $0 COMMAND PROJECTDIR [...globs]')
     .help('h')
     .alias('h', 'help')
-    .version(() => npm.name + ' ' + npm.version)
+    .version(npm.name + ' ' + npm.version)
     .alias('v', 'version')
     // -f flow-command-path
     .option('flow-command-path', {
       alias: 'f',
       type: 'string',
-      coerce: value => value.slice(0, 2) === './' ? path.resolve(value) : value,
+      coerce: (value: string) => value.slice(0, 2) === './' ? path.resolve(value) : value,
       describe: `path to the flow executable (defaults to "${defaultConfig.flowCommandPath}")`
     })
     // --type text
     .option('type', {
       alias: 't',
-      type: 'choice',
       choices: ['html', 'json', 'text', 'badge'],
       describe: `format of the generated reports (defaults to "${defaultConfig.type.join(', ')}")`
     })

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -83,7 +83,7 @@ export default function processArgv(argv: Array<string>) {
     })
     .option('exclude-non-flow', {
       type: 'boolean',
-      describe: 'Excludes flies without flow annotation from the report'
+      describe: 'Excludes files without flow annotation from the report'
     })
     // --no-config
     .option('no-config', {

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -81,6 +81,10 @@ export default function processArgv(argv) {
       describe: 'non annotated and flow weak files are considered as completely uncovered. ' +
         'Default behavior is for flow to best-guess coverage on all the files included in the report.'
     })
+    .option('exclude-non-flow', {
+      type: 'boolean',
+      describe: 'Excludes flies without flow annotation from the report'
+    })
     // --no-config
     .option('no-config', {
       type: 'boolean',

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -29,6 +29,7 @@ exports.run = () => {
     threshold: args.threshold,
     strictCoverage: args.strictCoverage,
     htmlTemplateOptions: args.htmlTemplateOptions,
+    excludeNonFlow: args.excludeNonFlow,
     flowCommandTimeout: args.flowCommandTimeout
   }).then(([coverageSummaryData]) => {
     const {percent, threshold} = coverageSummaryData;

--- a/src/lib/cli/index.js
+++ b/src/lib/cli/index.js
@@ -1,3 +1,4 @@
+// @flow
 import generateFlowCoverageReport from '../../lib';
 import processArgv from './args';
 import {loadConfig, validateConfig, UsageError} from './config';
@@ -27,10 +28,8 @@ exports.run = () => {
     reportTypes: args.type,
     threshold: args.threshold,
     strictCoverage: args.strictCoverage,
-    htmlTemplateOptions: args.htmlTemplateOptions
-  }).catch(err => {
-    console.error('Error while generating Flow Coverage Report: ' + err + ' ' + err.stack);
-    process.exit(255); // eslint-disable-line unicorn/no-process-exit
+    htmlTemplateOptions: args.htmlTemplateOptions,
+    flowCommandTimeout: args.flowCommandTimeout
   }).then(([coverageSummaryData]) => {
     const {percent, threshold} = coverageSummaryData;
     if (percent < threshold) {
@@ -39,5 +38,8 @@ exports.run = () => {
       );
       process.exit(2); // eslint-disable-line unicorn/no-process-exit
     }
+  }).catch(err => {
+    console.error('Error while generating Flow Coverage Report: ' + err + ' ' + err.stack);
+    process.exit(255); // eslint-disable-line unicorn/no-process-exit
   });
 };

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -335,6 +335,7 @@ export function collectFlowCoverage(
   concurrentFiles: number,
   tmpDirPath: ?string,
   strictCoverage: ?boolean,
+  excludeNonFlow: boolean
 ): Promise<FlowCoverageSummaryData> {
   return checkFlowStatus(flowCommandPath, projectDir, tmpDirPath).then(flowStatus => {
     const now = new Date();
@@ -398,8 +399,11 @@ export function collectFlowCoverage(
             }
 
             waitForCollectedDataFromFiles.push(collectFlowCoverageForFile(
-              flowCommandPath, flowCommandTimeout, projectDir, filename, tmpDirPath, strictCoverage,
+              flowCommandPath, flowCommandTimeout, projectDir, filename, tmpDirPath, strictCoverage
             ).then(data => {
+              if (excludeNonFlow && data.annotation !== 'flow') {
+                return;
+              }
               /* eslint-disable camelcase */
               coverageSummaryData.covered_count += data.expressions.covered_count;
               coverageSummaryData.uncovered_count += data.expressions.uncovered_count;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -27,7 +27,8 @@ export type FlowCoverageReportOptions = {
   threshold: number,
   strictCoverage: boolean,
   excludeNonFlow: boolean,
-  concurrentFiles?: number
+  concurrentFiles?: number,
+  log?: Function
 };
 
 // Default timeout for flow coverage commands.

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -26,8 +26,8 @@ export type FlowCoverageReportOptions = {
   htmlTemplateOptions?: Object,
   threshold: number,
   strictCoverage: boolean,
-  concurrentFiles?: number,
-  log: Function
+  excludeNonFlow: boolean,
+  concurrentFiles?: number
 };
 
 // Default timeout for flow coverage commands.
@@ -83,7 +83,8 @@ export default async function generateFlowCoverageReport(opts: FlowCoverageRepor
     opts.projectDir, opts.globIncludePatterns, opts.globExcludePatterns,
     opts.threshold, opts.concurrentFiles || 1,
     tmpDirPath,
-    opts.strictCoverage
+    opts.strictCoverage,
+    opts.excludeNonFlow
   );
 
   const reportResults = [];


### PR DESCRIPTION
Fixes this: https://github.com/rpl/flow-coverage-report/issues/85 by introducing `--exclude-non-flow` flag.

Reasoning is that project might contain legacy files which will never be turned into Flow, so it does not make sense to track coverage on them. Instead, it makes sense to concentrate on flow annotated files and their quality.

Also added bunch of libdefs and flow annotated few files :) 

ping @rpl 