### PR TITLE
fix: Support '@flow strict' pragma

### DIFF
--- a/__tests__/fixtures/flow-strict/src/local.js
+++ b/__tests__/fixtures/flow-strict/src/local.js
@@ -1,0 +1,1 @@
+// @flow strict-local

--- a/__tests__/fixtures/flow-strict/src/main.js
+++ b/__tests__/fixtures/flow-strict/src/main.js
@@ -1,0 +1,1 @@
+// @flow strict

--- a/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
+++ b/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
@@ -1,9 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Accept '@flow strict' pragma and treat it like '@flow' pragma 1`] = `
+exports[`Accept '@flow strict' and '@flow strict-local' pragmas 1`] = `
 Object {
-  "filteredStdout": Array [
-    "│ src/main.js │ flow strict │   100 % │     0 │       0 │ 0         │",
+  "filteredStdoutLocal": Array [
+    "│ src/local.js │ flow strict-local │   100 % │     0 │       0 │ 0         │",
+  ],
+  "filteredStdoutMain": Array [
+    "│ src/main.js  │       flow strict │   100 % │     0 │       0 │ 0         │",
   ],
   "stderr": "",
 }

--- a/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
+++ b/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accept '@flow strict' pragma and treat it like '@flow' pragma 1`] = `
+Object {
+  "filteredStdout": Array [
+    "│ src/main.js │ flow strict │   100 % │     0 │       0 │ 0         │",
+  ],
+  "stderr": "",
+}
+`;

--- a/__tests__/integrations/cli/test-flow-strict.js
+++ b/__tests__/integrations/cli/test-flow-strict.js
@@ -11,12 +11,13 @@ const testProjectDir = path.join(FIXTURE_PATH, 'flow-strict');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // 10 second timeout
 
-test('Accept \'@flow strict\' pragma and treat it like \'@flow\' pragma', async () => {
+test('Accept \'@flow strict\' and \'@flow strict-local\' pragmas', async () => {
   const {stdout, stderr} = await runFlowCoverageReport([
     '-i', `"src/*.js"`
   ], {cwd: testProjectDir});
 
-  const filteredStdout = stdout.split('\n').filter(line => line.indexOf('src/main') >= 0);
+  const filteredStdoutMain = stdout.split('\n').filter(line => line.indexOf('src/main') >= 0);
+  const filteredStdoutLocal = stdout.split('\n').filter(line => line.indexOf('src/local') >= 0);
 
-  expect({filteredStdout, stderr}).toMatchSnapshot();
+  expect({filteredStdoutMain, filteredStdoutLocal, stderr}).toMatchSnapshot();
 });

--- a/__tests__/integrations/cli/test-flow-strict.js
+++ b/__tests__/integrations/cli/test-flow-strict.js
@@ -1,0 +1,22 @@
+'use babel';
+
+import path from 'path';
+
+import {
+  FIXTURE_PATH,
+  runFlowCoverageReport
+} from '../../common';
+
+const testProjectDir = path.join(FIXTURE_PATH, 'flow-strict');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // 10 second timeout
+
+test('Accept \'@flow strict\' pragma and treat it like \'@flow\' pragma', async () => {
+  const {stdout, stderr} = await runFlowCoverageReport([
+    '-i', `"src/*.js"`
+  ], {cwd: testProjectDir});
+
+  const filteredStdout = stdout.split('\n').filter(line => line.indexOf('src/main') >= 0);
+
+  expect({filteredStdout, stderr}).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
     "badge-up": "2.3.0",
-    "flow-annotation-check": "1.8.1-0",
+    "flow-annotation-check": "1.8.1",
     "glob": "7.1.1",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
     "badge-up": "2.3.0",
-    "flow-annotation-check": "1.8.0",
+    "flow-annotation-check": "1.8.1-0",
     "glob": "7.1.1",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",

--- a/src/__tests__/fixtures.js
+++ b/src/__tests__/fixtures.js
@@ -9,8 +9,8 @@ const generatedAt = now.toDateString() + ' ' + now.toTimeString();
 
 const firstGlob = 'src/*.js';
 const secondGlob = 'src/*/*.js';
-const firstGlobResults = ['src/a.js', 'src/b.js'];
-const secondGlobResults = ['src/d1/c.js', 'src/d1/d.js'];
+const firstGlobResults = ['src/a.js', 'src/b.js', 'src/c.js'];
+const secondGlobResults = ['src/d1/d.js', 'src/d1/e.js'];
 
 const allFiles = [].concat(firstGlobResults, secondGlobResults);
 
@@ -18,8 +18,8 @@ const allFiles = [].concat(firstGlobResults, secondGlobResults);
 const FLOW_COVERAGE_SUMMARY_DATA = {
   flowStatus: {...FLOW_STATUS_PASSED},
   generatedAt,
-  covered_count: 4,
-  uncovered_count: 4,
+  covered_count: 5,
+  uncovered_count: 5,
   threshold: 40,
   percent: 50,
   globIncludePatterns: [firstGlob, secondGlob],

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
@@ -48,13 +48,13 @@ exports[`<HTMLReportBodySummary /> 1`] = `
                %
             </td>
             <td>
-              8
+              10
             </td>
             <td>
-              4
+              5
             </td>
             <td>
-              4
+              5
             </td>
           </tr>
         </tbody>
@@ -186,9 +186,9 @@ exports[`<HTMLReportBodySummary /> 1`] = `
               className="selectable"
             >
               <a
-                href="sourcefiles/src/d1/c.js.html"
+                href="sourcefiles/src/c.js.html"
               >
-                src/d1/c.js
+                src/c.js
               </a>
             </td>
             <td>
@@ -230,6 +230,47 @@ exports[`<HTMLReportBodySummary /> 1`] = `
                 href="sourcefiles/src/d1/d.js.html"
               >
                 src/d1/d.js
+              </a>
+            </td>
+            <td>
+               @
+              flow
+               
+            </td>
+            <td
+              className=""
+            >
+              <span>
+                50
+                 %
+              </span>
+            </td>
+            <td>
+               
+              2
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+          </tr>
+          <tr
+            className="positive"
+          >
+            <td
+              className="selectable"
+            >
+              <a
+                href="sourcefiles/src/d1/e.js.html"
+              >
+                src/d1/e.js
               </a>
             </td>
             <td>
@@ -335,13 +376,13 @@ exports[`<HTMLReportBodySummary /> 2`] = `
                %
             </td>
             <td>
-              8
+              10
             </td>
             <td>
-              4
+              5
             </td>
             <td>
-              4
+              5
             </td>
           </tr>
         </tbody>
@@ -473,9 +514,9 @@ exports[`<HTMLReportBodySummary /> 2`] = `
               className="selectable"
             >
               <a
-                href="sourcefiles/src/d1/c.js.html"
+                href="sourcefiles/src/c.js.html"
               >
-                src/d1/c.js
+                src/c.js
               </a>
             </td>
             <td>
@@ -517,6 +558,47 @@ exports[`<HTMLReportBodySummary /> 2`] = `
                 href="sourcefiles/src/d1/d.js.html"
               >
                 src/d1/d.js
+              </a>
+            </td>
+            <td>
+               @
+              flow
+               
+            </td>
+            <td
+              className=""
+            >
+              <span>
+                50
+                 %
+              </span>
+            </td>
+            <td>
+               
+              2
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+          </tr>
+          <tr
+            className="negative"
+          >
+            <td
+              className="selectable"
+            >
+              <a
+                href="sourcefiles/src/d1/e.js.html"
+              >
+                src/d1/e.js
               </a>
             </td>
             <td>

--- a/src/__tests__/react-components/__snapshots__/test-coverage-summary-table.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-coverage-summary-table.js.snap
@@ -29,13 +29,13 @@ exports[`<FlowCoverageSummaryTable /> 1`] = `
          %
       </td>
       <td>
-        8
+        10
       </td>
       <td>
-        4
+        5
       </td>
       <td>
-        4
+        5
       </td>
     </tr>
   </tbody>
@@ -71,13 +71,13 @@ exports[`<FlowCoverageSummaryTable /> 2`] = `
          %
       </td>
       <td>
-        8
+        10
       </td>
       <td>
-        4
+        5
       </td>
       <td>
-        4
+        5
       </td>
     </tr>
   </tbody>

--- a/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
@@ -54,13 +54,13 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                  %
               </td>
               <td>
-                8
+                10
               </td>
               <td>
-                4
+                5
               </td>
               <td>
-                4
+                5
               </td>
             </tr>
           </tbody>
@@ -192,9 +192,9 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                 className="selectable"
               >
                 <a
-                  href="sourcefiles/src/d1/c.js.html"
+                  href="sourcefiles/src/c.js.html"
                 >
-                  src/d1/c.js
+                  src/c.js
                 </a>
               </td>
               <td>
@@ -236,6 +236,47 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                   href="sourcefiles/src/d1/d.js.html"
                 >
                   src/d1/d.js
+                </a>
+              </td>
+              <td>
+                 @
+                flow
+                 
+              </td>
+              <td
+                className=""
+              >
+                <span>
+                  50
+                   %
+                </span>
+              </td>
+              <td>
+                 
+                2
+                 
+              </td>
+              <td>
+                 
+                1
+                 
+              </td>
+              <td>
+                 
+                1
+                 
+              </td>
+            </tr>
+            <tr
+              className="positive"
+            >
+              <td
+                className="selectable"
+              >
+                <a
+                  href="sourcefiles/src/d1/e.js.html"
+                >
+                  src/d1/e.js
                 </a>
               </td>
               <td>

--- a/src/__tests__/test-flow.js
+++ b/src/__tests__/test-flow.js
@@ -359,7 +359,7 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
   const secondGlobResults = ['src/d1/c.js', 'src/d1/d.js', 'test/subdir/test-d.js'];
   const expectedFlowAnnotations = {
     'src/a.js': 'flow',
-    'src/b.js': 'flow',
+    'src/b.js': 'flow strict',
     'src/d1/c.js': 'no flow',
     'src/d1/d.js': 'flow weak'
   };
@@ -474,7 +474,7 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
     delete resFiles[filename].expressions.uncovered_locs;
 
     // Detect if the single file coverage is expected to be 0.
-    const forceNoCoverage = !(!strictCoverage || expectedFlowAnnotations[filename] === 'flow');
+    const forceNoCoverage = !(!strictCoverage || ['flow', 'flow strict'].indexOf(expectedFlowAnnotations[filename]) !== -1);
 
     expect(resFiles[filename]).toEqual({
       percent: forceNoCoverage ? 0 : 50,

--- a/src/__tests__/test-flow.js
+++ b/src/__tests__/test-flow.js
@@ -355,13 +355,14 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
     flowVersion: '0.30.0'
   };
 
-  const firstGlobResults = ['src/a.js', 'src/b.js', 'test/test-a.js'];
-  const secondGlobResults = ['src/d1/c.js', 'src/d1/d.js', 'test/subdir/test-d.js'];
+  const firstGlobResults = ['src/a.js', 'src/b.js', 'src/c.js', 'test/test-a.js'];
+  const secondGlobResults = ['src/d1/d.js', 'src/d1/e.js', 'test/subdir/test-d.js'];
   const expectedFlowAnnotations = {
     'src/a.js': 'flow',
     'src/b.js': 'flow strict',
-    'src/d1/c.js': 'no flow',
-    'src/d1/d.js': 'flow weak'
+    'src/c.js': 'flow strict-local',
+    'src/d1/d.js': 'no flow',
+    'src/d1/e.js': 'flow weak'
   };
 
   // Fake reply to flow status command.
@@ -450,8 +451,8 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
     percent: 50,
     threshold: 80,
     /* eslint-disable camelcase */
-    covered_count: 4,
-    uncovered_count: 4,
+    covered_count: 5,
+    uncovered_count: 5,
     /* eslint-enable camelcase */
     ...expectedResults
   });
@@ -474,7 +475,11 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
     delete resFiles[filename].expressions.uncovered_locs;
 
     // Detect if the single file coverage is expected to be 0.
-    const forceNoCoverage = !(!strictCoverage || ['flow', 'flow strict'].indexOf(expectedFlowAnnotations[filename]) !== -1);
+    const forceNoCoverage = !(!strictCoverage || [
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(expectedFlowAnnotations[filename]) !== -1);
 
     expect(resFiles[filename]).toEqual({
       percent: forceNoCoverage ? 0 : 50,
@@ -490,7 +495,7 @@ const testCollectFlowCoverage = async ({expectedResults, strictCoverage} = {}) =
   }
 
   expect(mockWriteFile.mock.calls.length).toBe(0);
-  expect(mockExec.mock.calls.length).toBe(5);
+  expect(mockExec.mock.calls.length).toBe(6);
   expect(mockGlob.mock.calls.length).toBe(2);
 };
 
@@ -500,10 +505,10 @@ it('collectFlowCoverage', async () => {
 
 it('collectFlowCoverage - strictCoverage mode', async () => {
   await testCollectFlowCoverage({strictCoverage: true, expectedResults: {
-    percent: 25,
+    percent: 30,
     /* eslint-disable camelcase */
-    covered_count: 2,
-    uncovered_count: 6
+    covered_count: 3,
+    uncovered_count: 7
     /* eslint-enable camelcase */
   }});
 });

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -38,7 +38,7 @@ export default function FlowCoverageFileTableRow(
     threshold
   } = props;
 
-  const isFlow = annotation === 'flow';
+  const isFlow = ['flow', 'flow strict', 'flow strict-local'].indexOf(annotation) !== -1;
   const aboveThreshold = percent >= threshold;
   let className = (!isError && isFlow && aboveThreshold) ?
     'positive' : 'negative';

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -142,7 +142,13 @@ export type FlowCoverageJSONData = {
     uncovered_locs: Array<FlowUncoveredLoc>
   },
   filename?: string,
-  annotation?: 'no flow' | 'flow weak' | 'flow' | 'flow strict',
+  // eslint-disable-next-line flowtype/space-after-type-colon
+  annotation?:
+    | 'no flow'
+    | 'flow weak'
+    | 'flow'
+    | 'flow strict'
+    | 'flow strict-local',
   percent: number,
   error?: string,
   isError?: boolean,
@@ -247,7 +253,11 @@ export async function collectFlowCoverageForFile(
     // In strictCoverage mode all files that are not strictly flow
     // (e.g. non annotated and flow weak files) are considered
     // as completely uncovered.
-    if (strictCoverage && ['flow', 'flow strict'].indexOf(parsedData.annotation) === -1) {
+    if (strictCoverage && [
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(parsedData.annotation) === -1) {
       parsedData.expressions.uncovered_count += parsedData.expressions.covered_count;
       parsedData.expressions.covered_count = 0;
     }
@@ -304,6 +314,7 @@ export function summarizeAnnotations(
     switch (coverageSummaryData.files[filename].annotation) {
       case 'flow':
       case 'flow strict':
+      case 'flow strict-local':
         flowFiles += 1;
         break;
       case 'flow weak':

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -142,7 +142,7 @@ export type FlowCoverageJSONData = {
     uncovered_locs: Array<FlowUncoveredLoc>
   },
   filename?: string,
-  annotation?: 'no flow' | 'flow weak' | 'flow',
+  annotation?: 'no flow' | 'flow weak' | 'flow' | 'flow strict',
   percent: number,
   error?: string,
   isError?: boolean,
@@ -247,7 +247,7 @@ export async function collectFlowCoverageForFile(
     // In strictCoverage mode all files that are not strictly flow
     // (e.g. non annotated and flow weak files) are considered
     // as completely uncovered.
-    if (strictCoverage && parsedData.annotation !== 'flow') {
+    if (strictCoverage && ['flow', 'flow strict'].indexOf(parsedData.annotation) === -1) {
       parsedData.expressions.uncovered_count += parsedData.expressions.covered_count;
       parsedData.expressions.covered_count = 0;
     }
@@ -303,6 +303,7 @@ export function summarizeAnnotations(
   filenames.forEach(filename => {
     switch (coverageSummaryData.files[filename].annotation) {
       case 'flow':
+      case 'flow strict':
         flowFiles += 1;
         break;
       case 'flow weak':

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -48,7 +48,11 @@ function renderTextReport(
     ]);
 
     let rowColor;
-    if (annotation === 'flow' && percent >= (opts.threshold || 80)) {
+    if ([
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(annotation) !== -1 && percent >= (opts.threshold || 80)) {
       rowColor = 'green';
     } else {
       rowColor = 'red';


### PR DESCRIPTION
Trying to run coverage on a file that has the new [`@flow strict`](https://flow.org/en/docs/strict/) pragma results in:

```
Error while generating Flow Coverage Report: Error: Unexpected missing flow annotation on index.js Error: Unexpected missing flow annotation on index.js
    at /home/zeorin/code/my-framework/node_modules/flow-coverage-report/dist/lib/flow.js:336:15
    at Array.forEach (<anonymous>)
    at summarizeAnnotations (/home/zeorin/code/my-framework/node_modules/flow-coverage-report/dist/lib/flow.js:324:13)
    at /home/zeorin/code/my-framework/node_modules/flow-coverage-report/dist/lib/flow.js:577:45
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```
This fixes that by treating it the same as the regular `@flow` pragma for coverage purposes.