### PR TITLE
fix: Added support for the new flow annotations (strict and strict-local)

### DIFF
--- a/__tests__/fixtures/flow-strict/src/local.js
+++ b/__tests__/fixtures/flow-strict/src/local.js
@@ -1,0 +1,1 @@
+// @flow strict-local

--- a/__tests__/fixtures/flow-strict/src/main.js
+++ b/__tests__/fixtures/flow-strict/src/main.js
@@ -1,0 +1,1 @@
+// @flow strict

--- a/__tests__/fixtures/legacy-config-warns/legacy-config.json
+++ b/__tests__/fixtures/legacy-config-warns/legacy-config.json
@@ -1,0 +1,9 @@
+{
+  "excludeGlob": [
+    "node_modules/**"
+  ],
+  "includeGlob": [
+    "src/**/*.js"
+  ],
+  "type": "text"
+}

--- a/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
+++ b/__tests__/integrations/cli/__snapshots__/test-flow-strict.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Accept '@flow strict' and '@flow strict-local' pragmas 1`] = `
+Object {
+  "filteredStdoutLocal": Array [
+    "│ src/local.js │ flow strict-local │   100 % │     0 │       0 │ 0         │",
+  ],
+  "filteredStdoutMain": Array [
+    "│ src/main.js  │       flow strict │   100 % │     0 │       0 │ 0         │",
+  ],
+  "stderr": "",
+}
+`;

--- a/__tests__/integrations/cli/__snapshots__/test-legacy-config-warns.js.snap
+++ b/__tests__/integrations/cli/__snapshots__/test-legacy-config-warns.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Legacy config warnings should log warning messages for legacy config names 1`] = `
+Object {
+  "error": null,
+  "exitCode": 0,
+  "stderr": "WARN: \\"includeGlob\\" config file property has been renamed to \\"globIncludePatterns\\"
+WARN: \\"excludeGlob\\" config file property has been renamed to \\"globExcludePatterns\\"
+WARN: \\"type\\" config file property has been renamed to \\"reportTypes\\"
+",
+}
+`;

--- a/__tests__/integrations/cli/test-flow-strict.js
+++ b/__tests__/integrations/cli/test-flow-strict.js
@@ -1,0 +1,23 @@
+'use babel';
+
+import path from 'path';
+
+import {
+  FIXTURE_PATH,
+  runFlowCoverageReport
+} from '../../common';
+
+const testProjectDir = path.join(FIXTURE_PATH, 'flow-strict');
+
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // 10 second timeout
+
+test('Accept \'@flow strict\' and \'@flow strict-local\' pragmas', async () => {
+  const {stdout, stderr} = await runFlowCoverageReport([
+    '-i', `"src/*.js"`
+  ], {cwd: testProjectDir});
+
+  const filteredStdoutMain = stdout.split('\n').filter(line => line.indexOf('src/main') >= 0);
+  const filteredStdoutLocal = stdout.split('\n').filter(line => line.indexOf('src/local') >= 0);
+
+  expect({filteredStdoutMain, filteredStdoutLocal, stderr}).toMatchSnapshot();
+});

--- a/__tests__/integrations/cli/test-legacy-config-warns.js
+++ b/__tests__/integrations/cli/test-legacy-config-warns.js
@@ -1,0 +1,20 @@
+'use babel';
+
+import path from 'path';
+
+import {
+  FIXTURE_PATH,
+  runFlowCoverageReport
+} from '../../common';
+
+const testProjectDir = path.join(FIXTURE_PATH, 'legacy-config-warns');
+
+describe('Legacy config warnings', () => {
+  it('should log warning messages for legacy config names', async () => {
+    const {exitCode, error, stderr} = await runFlowCoverageReport([
+      '--config', 'legacy-config.json'
+    ], {cwd: testProjectDir});
+
+    expect({exitCode, error, stderr}).toMatchSnapshot();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
     "badge-up": "2.3.0",
-    "flow-annotation-check": "1.8.0",
+    "flow-annotation-check": "1.8.1",
     "glob": "7.1.1",
     "minimatch": "3.0.4",
     "mkdirp": "0.5.1",

--- a/src/__tests__/fixtures.js
+++ b/src/__tests__/fixtures.js
@@ -9,8 +9,8 @@ const generatedAt = now.toDateString() + ' ' + now.toTimeString();
 
 const firstGlob = 'src/*.js';
 const secondGlob = 'src/*/*.js';
-const firstGlobResults = ['src/a.js', 'src/b.js'];
-const secondGlobResults = ['src/d1/c.js', 'src/d1/d.js'];
+const firstGlobResults = ['src/a.js', 'src/b.js', 'src/c.js'];
+const secondGlobResults = ['src/d1/d.js', 'src/d1/e.js'];
 
 const allFiles = [].concat(firstGlobResults, secondGlobResults);
 
@@ -18,8 +18,8 @@ const allFiles = [].concat(firstGlobResults, secondGlobResults);
 const FLOW_COVERAGE_SUMMARY_DATA = {
   flowStatus: {...FLOW_STATUS_PASSED},
   generatedAt,
-  covered_count: 4,
-  uncovered_count: 4,
+  covered_count: 5,
+  uncovered_count: 5,
   threshold: 40,
   percent: 50,
   globIncludePatterns: [firstGlob, secondGlob],

--- a/src/__tests__/fixtures.js
+++ b/src/__tests__/fixtures.js
@@ -12,6 +12,18 @@ const secondGlob = 'src/*/*.js';
 const firstGlobResults = ['src/a.js', 'src/b.js', 'src/c.js'];
 const secondGlobResults = ['src/d1/d.js', 'src/d1/e.js'];
 
+const fakeTypeAnnotations = {
+  'src/c.js': 'no flow',
+  'src/d1/d.js': 'flow strict',
+  'src/d1/e.js': 'flow strict-local'
+};
+
+const fakeIsFlow = {
+  'src/c.js': false,
+  'src/d1/d.js': true,
+  'src/d1/e.js': true
+};
+
 const allFiles = [].concat(firstGlobResults, secondGlobResults);
 
 /* eslint-disable camelcase */
@@ -26,7 +38,8 @@ const FLOW_COVERAGE_SUMMARY_DATA = {
   files: allFiles.reduce((acc, filename) => {
     acc[filename] = {
       percent: 50,
-      annotation: 'flow',
+      annotation: fakeTypeAnnotations[filename] || 'flow',
+      isFlow: filename in fakeIsFlow ? fakeIsFlow[filename] : true,
       expressions: {
         covered_count: 1,
         uncovered_count: 1,

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-sourcefile.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-sourcefile.js.snap
@@ -193,7 +193,7 @@ exports[`<HTMLReportBodySourceFile /> 1`] = `
       }
     }
   >
-    {"percent":50,"annotation":"flow","expressions":{"covered_count":1,"uncovered_count":1,"uncovered_locs":[{"start":{"line":1,"column":1,"offset":10},"end":{"line":2,"column":2,"offset":30}}]}}
+    {"percent":50,"annotation":"flow","isFlow":true,"expressions":{"covered_count":1,"uncovered_count":1,"uncovered_locs":[{"start":{"line":1,"column":1,"offset":10},"end":{"line":2,"column":2,"offset":30}}]}}
   </pre>
 </body>
 `;

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
@@ -180,7 +180,7 @@ exports[`<HTMLReportBodySummary /> 1`] = `
             </td>
           </tr>
           <tr
-            className="positive"
+            className="negative"
           >
             <td
               className="selectable"
@@ -193,7 +193,7 @@ exports[`<HTMLReportBodySummary /> 1`] = `
             </td>
             <td>
                @
-              flow
+              no flow
                
             </td>
             <td
@@ -234,7 +234,7 @@ exports[`<HTMLReportBodySummary /> 1`] = `
             </td>
             <td>
                @
-              flow
+              flow strict
                
             </td>
             <td
@@ -275,7 +275,7 @@ exports[`<HTMLReportBodySummary /> 1`] = `
             </td>
             <td>
                @
-              flow
+              flow strict-local
                
             </td>
             <td
@@ -521,7 +521,7 @@ exports[`<HTMLReportBodySummary /> 2`] = `
             </td>
             <td>
                @
-              flow
+              no flow
                
             </td>
             <td
@@ -562,7 +562,7 @@ exports[`<HTMLReportBodySummary /> 2`] = `
             </td>
             <td>
                @
-              flow
+              flow strict
                
             </td>
             <td
@@ -603,7 +603,7 @@ exports[`<HTMLReportBodySummary /> 2`] = `
             </td>
             <td>
                @
-              flow
+              flow strict-local
                
             </td>
             <td

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
@@ -48,13 +48,13 @@ exports[`<HTMLReportBodySummary /> 1`] = `
                %
             </td>
             <td>
-              8
+              10
             </td>
             <td>
-              4
+              5
             </td>
             <td>
-              4
+              5
             </td>
           </tr>
         </tbody>
@@ -186,9 +186,9 @@ exports[`<HTMLReportBodySummary /> 1`] = `
               className="selectable"
             >
               <a
-                href="sourcefiles/src/d1/c.js.html"
+                href="sourcefiles/src/c.js.html"
               >
-                src/d1/c.js
+                src/c.js
               </a>
             </td>
             <td>
@@ -230,6 +230,47 @@ exports[`<HTMLReportBodySummary /> 1`] = `
                 href="sourcefiles/src/d1/d.js.html"
               >
                 src/d1/d.js
+              </a>
+            </td>
+            <td>
+               @
+              flow
+               
+            </td>
+            <td
+              className=""
+            >
+              <span>
+                50
+                 %
+              </span>
+            </td>
+            <td>
+               
+              2
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+          </tr>
+          <tr
+            className="positive"
+          >
+            <td
+              className="selectable"
+            >
+              <a
+                href="sourcefiles/src/d1/e.js.html"
+              >
+                src/d1/e.js
               </a>
             </td>
             <td>
@@ -335,13 +376,13 @@ exports[`<HTMLReportBodySummary /> 2`] = `
                %
             </td>
             <td>
-              8
+              10
             </td>
             <td>
-              4
+              5
             </td>
             <td>
-              4
+              5
             </td>
           </tr>
         </tbody>
@@ -473,9 +514,9 @@ exports[`<HTMLReportBodySummary /> 2`] = `
               className="selectable"
             >
               <a
-                href="sourcefiles/src/d1/c.js.html"
+                href="sourcefiles/src/c.js.html"
               >
-                src/d1/c.js
+                src/c.js
               </a>
             </td>
             <td>
@@ -517,6 +558,47 @@ exports[`<HTMLReportBodySummary /> 2`] = `
                 href="sourcefiles/src/d1/d.js.html"
               >
                 src/d1/d.js
+              </a>
+            </td>
+            <td>
+               @
+              flow
+               
+            </td>
+            <td
+              className=""
+            >
+              <span>
+                50
+                 %
+              </span>
+            </td>
+            <td>
+               
+              2
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+            <td>
+               
+              1
+               
+            </td>
+          </tr>
+          <tr
+            className="negative"
+          >
+            <td
+              className="selectable"
+            >
+              <a
+                href="sourcefiles/src/d1/e.js.html"
+              >
+                src/d1/e.js
               </a>
             </td>
             <td>

--- a/src/__tests__/react-components/__snapshots__/test-coverage-summary-table.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-coverage-summary-table.js.snap
@@ -29,13 +29,13 @@ exports[`<FlowCoverageSummaryTable /> 1`] = `
          %
       </td>
       <td>
-        8
+        10
       </td>
       <td>
-        4
+        5
       </td>
       <td>
-        4
+        5
       </td>
     </tr>
   </tbody>
@@ -71,13 +71,13 @@ exports[`<FlowCoverageSummaryTable /> 2`] = `
          %
       </td>
       <td>
-        8
+        10
       </td>
       <td>
-        4
+        5
       </td>
       <td>
-        4
+        5
       </td>
     </tr>
   </tbody>

--- a/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
@@ -186,7 +186,7 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
               </td>
             </tr>
             <tr
-              className="positive"
+              className="negative"
             >
               <td
                 className="selectable"
@@ -199,7 +199,7 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
               </td>
               <td>
                  @
-                flow
+                no flow
                  
               </td>
               <td
@@ -240,7 +240,7 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
               </td>
               <td>
                  @
-                flow
+                flow strict
                  
               </td>
               <td
@@ -281,7 +281,7 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
               </td>
               <td>
                  @
-                flow
+                flow strict-local
                  
               </td>
               <td

--- a/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
@@ -54,13 +54,13 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                  %
               </td>
               <td>
-                8
+                10
               </td>
               <td>
-                4
+                5
               </td>
               <td>
-                4
+                5
               </td>
             </tr>
           </tbody>
@@ -192,9 +192,9 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                 className="selectable"
               >
                 <a
-                  href="sourcefiles/src/d1/c.js.html"
+                  href="sourcefiles/src/c.js.html"
                 >
-                  src/d1/c.js
+                  src/c.js
                 </a>
               </td>
               <td>
@@ -236,6 +236,47 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
                   href="sourcefiles/src/d1/d.js.html"
                 >
                   src/d1/d.js
+                </a>
+              </td>
+              <td>
+                 @
+                flow
+                 
+              </td>
+              <td
+                className=""
+              >
+                <span>
+                  50
+                   %
+                </span>
+              </td>
+              <td>
+                 
+                2
+                 
+              </td>
+              <td>
+                 
+                1
+                 
+              </td>
+              <td>
+                 
+                1
+                 
+              </td>
+            </tr>
+            <tr
+              className="positive"
+            >
+              <td
+                className="selectable"
+              >
+                <a
+                  href="sourcefiles/src/d1/e.js.html"
+                >
+                  src/d1/e.js
                 </a>
               </td>
               <td>

--- a/src/__tests__/test-flow.js
+++ b/src/__tests__/test-flow.js
@@ -357,13 +357,14 @@ const testCollectFlowCoverage = async ({
     flowVersion: '0.30.0'
   };
 
-  const firstGlobResults = ['src/a.js', 'src/b.js', 'test/test-a.js'];
-  const secondGlobResults = ['src/d1/c.js', 'src/d1/d.js', 'test/subdir/test-d.js'];
+  const firstGlobResults = ['src/a.js', 'src/b.js', 'src/c.js', 'test/test-a.js'];
+  const secondGlobResults = ['src/d1/d.js', 'src/d1/e.js', 'test/subdir/test-d.js'];
   const expectedFlowAnnotations = {
     'src/a.js': 'flow',
-    'src/b.js': 'flow',
-    'src/d1/c.js': 'no flow',
-    'src/d1/d.js': 'flow weak'
+    'src/b.js': 'flow strict',
+    'src/c.js': 'flow strict-local',
+    'src/d1/d.js': 'no flow',
+    'src/d1/e.js': 'flow weak'
   };
 
   // Fake reply to flow status command.
@@ -455,8 +456,8 @@ const testCollectFlowCoverage = async ({
     percent: 50,
     threshold: 80,
     /* eslint-disable camelcase */
-    covered_count: excludeNonFlow ? 3 : 4,
-    uncovered_count: excludeNonFlow ? 3 : 4,
+    covered_count: excludeNonFlow ? 4 : 5,
+    uncovered_count: excludeNonFlow ? 4 : 5,
     /* eslint-enable camelcase */
     ...expectedResults
   });
@@ -490,7 +491,11 @@ const testCollectFlowCoverage = async ({
     delete resFiles[filename].expressions.uncovered_locs;
 
     // Detect if the single file coverage is expected to be 0.
-    const forceNoCoverage = !(!strictCoverage || expectedFlowAnnotations[filename] === 'flow');
+    const forceNoCoverage = !(!strictCoverage || [
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(expectedFlowAnnotations[filename]) !== -1);
 
     if (excludeNonFlow && expectedFlowAnnotations[filename] === 'no flow') {
       expect(resFiles[filename]).toEqual(undefined);
@@ -510,7 +515,7 @@ const testCollectFlowCoverage = async ({
   }
 
   expect(mockWriteFile.mock.calls.length).toBe(0);
-  expect(mockExec.mock.calls.length).toBe(excludeNonFlow ? 4 : 5);
+  expect(mockExec.mock.calls.length).toBe(excludeNonFlow ? 5 : 6);
   expect(mockGlob.mock.calls.length).toBe(2);
 };
 
@@ -522,10 +527,10 @@ it('collectFlowCoverage - strictCoverage mode', async () => {
   await testCollectFlowCoverage({
     strictCoverage: true,
     expectedResults: {
-      percent: 25,
+      percent: 30,
       /* eslint-disable camelcase */
-      covered_count: 2,
-      uncovered_count: 6
+      covered_count: 3,
+      uncovered_count: 7
       /* eslint-enable camelcase */
     }
   });

--- a/src/__tests__/test-flow.js
+++ b/src/__tests__/test-flow.js
@@ -2,7 +2,7 @@
 
 import minimatch from 'minimatch';
 
-import {DEFAULT_FLOW_TIMEOUT} from '../lib/index';
+import {DEFAULT_FLOW_TIMEOUT} from '../lib/cli/config';
 import {isFlowAnnotation} from '../lib/flow';
 
 const LIB_FLOW = '../lib/flow';

--- a/src/__tests__/test-flow.js
+++ b/src/__tests__/test-flow.js
@@ -3,6 +3,7 @@
 import minimatch from 'minimatch';
 
 import {DEFAULT_FLOW_TIMEOUT} from '../lib/index';
+import {isFlowAnnotation} from '../lib/flow';
 
 const LIB_FLOW = '../lib/flow';
 const LIB_PROMISIFIED = '../lib/promisified';
@@ -326,7 +327,8 @@ it('collectFlowCoverageForFile resolve coverage data', async () => {
   });
   expect(res).toEqual({
     ...fakeFlowCoverageData,
-    annotation: 'flow'
+    annotation: 'flow',
+    isFlow: true
   });
 });
 
@@ -450,7 +452,7 @@ const testCollectFlowCoverage = async ({
     },
     globIncludePatterns,
     globExcludePatterns,
-    strictCoverage,
+    strictCoverage: Boolean(strictCoverage),
     excludeNonFlow,
     concurrentFiles: 5,
     percent: 50,
@@ -504,6 +506,7 @@ const testCollectFlowCoverage = async ({
         percent: forceNoCoverage ? 0 : 50,
         filename,
         annotation: expectedFlowAnnotations[filename],
+        isFlow: isFlowAnnotation(expectedFlowAnnotations[filename], Boolean(strictCoverage)),
         expressions: {
           /* eslint-disable camelcase */
           covered_count: forceNoCoverage ? 0 : 1,

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -33,8 +33,9 @@ export default function processArgv(argv: Array<string>): any {
       alias: 'f',
       type: 'string',
       coerce: (value: mixed) => {
-        if (value !== 'string') {
-          throw new TypeError('Unexpected non-string value');
+        if (typeof value !== 'string') {
+          // $FlowIgnoreMe: allow value to be coerced to a string.
+          throw new TypeError(`Unexpected non-string value: ${value}`);
         }
         return value.slice(0, 2) === './' ? path.resolve(value) : value;
       },

--- a/src/lib/components/body-coverage-sourcefile.jsx
+++ b/src/lib/components/body-coverage-sourcefile.jsx
@@ -114,6 +114,7 @@ export default function HTMLReportBodySourceFile(props: FlowCoverageSourceFileRe
                   flowCoverageException: coverageData.flowCoverageException,
                   flowCoverageStderr: coverageData.flowCoverageStderr,
                   isError: coverageData.isError,
+                  isFlow: coverageData.isFlow,
                   percent,
                   threshold,
                   /* eslint-disable camelcase */

--- a/src/lib/components/body-coverage-summary.jsx
+++ b/src/lib/components/body-coverage-summary.jsx
@@ -37,6 +37,7 @@ export default function HTMLReportBodySummary(props: FlowCoverageSummaryReportPr
             const fileRowProps = {
               filename,
               isError: fileSummary.isError,
+              isFlow: fileSummary.isFlow,
               flowCoverageParsingError: fileSummary.flowCoverageParsingError,
               flowCoverageError: fileSummary.flowCoverageError,
               flowCoverageException: fileSummary.flowCoverageException,

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -38,7 +38,7 @@ export default function FlowCoverageFileTableRow(
     threshold
   } = props;
 
-  const isFlow = annotation === 'flow';
+  const isFlow = ['flow', 'flow strict', 'flow strict-local'].indexOf(annotation) !== -1;
   const aboveThreshold = percent >= threshold;
   let className = (!isError && isFlow && aboveThreshold) ?
     'positive' : 'negative';

--- a/src/lib/components/coverage-file-table-row.jsx
+++ b/src/lib/components/coverage-file-table-row.jsx
@@ -20,6 +20,7 @@ export default function FlowCoverageFileTableRow(
     disableLink: boolean,
     threshold: number,
     isError: boolean,
+    isFlow: boolean,
     flowCoverageError: ?string,
     flowCoverageParsingError: ?string,
     flowCoverageException: ?string,
@@ -34,11 +35,11 @@ export default function FlowCoverageFileTableRow(
     uncovered_count,
     percent,
     isError,
+    isFlow,
     disableLink,
     threshold
   } = props;
 
-  const isFlow = ['flow', 'flow strict', 'flow strict-local'].indexOf(annotation) !== -1;
   const aboveThreshold = percent >= threshold;
   let className = (!isError && isFlow && aboveThreshold) ?
     'positive' : 'negative';

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -143,7 +143,13 @@ export type FlowCoverageJSONData = {
     uncovered_locs: Array<FlowUncoveredLoc>
   },
   filename?: string,
-  annotation?: 'no flow' | 'flow weak' | 'flow',
+  // eslint-disable-next-line flowtype/space-after-type-colon
+  annotation?:
+    | 'no flow'
+    | 'flow weak'
+    | 'flow'
+    | 'flow strict'
+    | 'flow strict-local',
   percent: number,
   error?: string,
   isError?: boolean,
@@ -249,7 +255,11 @@ export async function collectFlowCoverageForFile(
     // In strictCoverage mode all files that are not strictly flow
     // (e.g. non annotated and flow weak files) are considered
     // as completely uncovered.
-    if (strictCoverage && parsedData.annotation !== 'flow') {
+    if (strictCoverage && [
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(parsedData.annotation) === -1) {
       parsedData.expressions.uncovered_count += parsedData.expressions.covered_count;
       parsedData.expressions.covered_count = 0;
     }
@@ -305,6 +315,8 @@ export function summarizeAnnotations(
   filenames.forEach(filename => {
     switch (coverageSummaryData.files[filename].annotation) {
       case 'flow':
+      case 'flow strict':
+      case 'flow strict-local':
         flowFiles += 1;
         break;
       case 'flow weak':

--- a/src/lib/flow.js
+++ b/src/lib/flow.js
@@ -216,7 +216,7 @@ export async function collectFlowCoverageForFile(
     {dontReject: true});
 
   if (res.err) {
-    console.error(`ERROR Collecting coverage data from ${filename} `, filename, res.err, res.stderr);
+    console.error('ERROR Collecting coverage data from', filename, res.err, res.stderr);
 
     if (process.env.VERBOSE) {
       if (tmpFilePath) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -4,6 +4,7 @@
 
 import path from 'path';
 
+import {DEFAULT_FLOW_TIMEOUT} from './cli/config';
 import {collectFlowCoverage} from './flow';
 import {withTmpDir} from './promisified';
 import reportHTML from './report-html';
@@ -11,28 +12,17 @@ import reportBadge from './report-badge';
 import reportJSON from './report-json';
 import reportText from './report-text';
 
-import type {FlowCoverageSummaryData} from './flow'; // eslint-disable-line no-duplicate-imports
+// eslint-disable-next-line no-duplicate-imports
+import type {ConfigParams, ReportType} from './cli/config';
+// eslint-disable-next-line no-duplicate-imports
+import type {FlowCoverageSummaryData} from './flow';
 
-export type FlowCoverageReportType = 'json' | 'text' | 'badge' |'html';
+export type FlowCoverageReportType = ReportType;
 
 export type FlowCoverageReportOptions = {
-  projectDir: string,
-  flowCommandPath: string,
-  flowCommandTimeout: number,
-  globIncludePatterns: Array<string>,
-  globExcludePatterns: Array<string>,
-  outputDir: string,
-  reportTypes?: Array<FlowCoverageReportType>,
-  htmlTemplateOptions?: Object,
-  threshold: number,
-  strictCoverage: boolean,
-  excludeNonFlow: boolean,
-  concurrentFiles?: number,
+  ...ConfigParams,
   log?: Function
 };
-
-// Default timeout for flow coverage commands.
-export const DEFAULT_FLOW_TIMEOUT = 15 * 1000;
 
 // User Scenarios
 // 1. generate text report from a project dir

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -48,7 +48,11 @@ function renderTextReport(
     ]);
 
     let rowColor;
-    if (annotation === 'flow' && percent >= (opts.threshold || 80)) {
+    if ([
+      'flow',
+      'flow strict',
+      'flow strict-local'
+    ].indexOf(annotation) !== -1 && percent >= (opts.threshold || 80)) {
       rowColor = 'green';
     } else {
       rowColor = 'red';

--- a/src/lib/report-text.js
+++ b/src/lib/report-text.js
@@ -48,11 +48,7 @@ function renderTextReport(
     ]);
 
     let rowColor;
-    if ([
-      'flow',
-      'flow strict',
-      'flow strict-local'
-    ].indexOf(annotation) !== -1 && percent >= (opts.threshold || 80)) {
+    if (data.isFlow && percent >= (opts.threshold || 80)) {
       rowColor = 'green';
     } else {
       rowColor = 'red';


### PR DESCRIPTION
This PR contains the changes from #150 rebased on top of the current master tip, with some small refactorings (as agreed in https://github.com/rpl/flow-coverage-report/pull/150#discussion_r190037717) and some additions and tweaks to the tests (and updates on the related jest snapshots). 

TODO:
- [ ] fix regression with renamed config option names (keep backward compatibility and log a working before releasing this change)