### PR TITLE
Trust in semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,20 +40,20 @@
     "url": "git+https://github.com/rpl/flow-coverage-report.git"
   },
   "dependencies": {
-    "array.prototype.find": "2.0.4",
-    "babel-runtime": "6.23.0",
-    "badge-up": "2.3.0",
-    "flow-annotation-check": "1.8.1",
-    "glob": "7.1.1",
-    "minimatch": "3.0.4",
+    "array.prototype.find": "^2.0.4",
+    "babel-runtime": "^6.23.0",
+    "badge-up": "^2.3.0",
+    "flow-annotation-check": "^1.8.1",
+    "glob": "^7.1.1",
+    "minimatch": "^3.0.4",
     "mkdirp": "0.5.1",
-    "parse-json": "2.2.0",
-    "react": "15.5.4",
-    "react-dom": "15.5.4",
-    "strip-json-comments": "2.0.1",
+    "parse-json": "^2.2.0",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "strip-json-comments": "^2.0.1",
     "temp": "0.8.3",
     "terminal-table": "0.0.12",
-    "yargs": "8.0.1"
+    "yargs": "^8.0.1"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",


### PR DESCRIPTION
Will reduce duplication in `node_modules` when it already has newer versions of these dependencies.

Fixes #122 

#164 does the same for react deps