### PR TITLE
remove custom suppress comments

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,5 +13,3 @@ src/.*
 flow-typed/npm
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
-suppress_comment= \\(.\\|\n\\)*\\$FlowIgnoreMe

--- a/src/lib/cli/args.js
+++ b/src/lib/cli/args.js
@@ -34,7 +34,7 @@ export default function processArgv(argv: Array<string>): any {
       type: 'string',
       coerce: (value: mixed) => {
         if (typeof value !== 'string') {
-          // $FlowIgnoreMe: allow value to be coerced to a string.
+          // $FlowFixMe: allow value to be coerced to a string.
           throw new TypeError(`Unexpected non-string value: ${value}`);
         }
         return value.slice(0, 2) === './' ? path.resolve(value) : value;

--- a/src/lib/cli/config.js
+++ b/src/lib/cli/config.js
@@ -160,7 +160,7 @@ export function loadConfig(args: Object): Object {
 
   try {
     packageJSONPath = path.resolve(path.join(getProjectDir(args), 'package.json'));
-    // $FlowIgnoreMe: the following dynamic require loads only the package.json file.
+    // $FlowFixMe: the following dynamic require loads only the package.json file.
     const pkg = require(packageJSONPath); // eslint-disable-line import/no-dynamic-require
     if (pkg['flow-coverage-report']) {
       if (process.env.VERBOSE) {


### PR DESCRIPTION
By using custom comments projects consuming this library have to either
explicitly ignore this module, or add the custom suppression comments.
Neither seems necessary, so this commit removes custom to fall back
to default `$FlowFixMe` comment.

Documentation about the default can be found [here](https://flow.org/en/docs/config/options/#toc-suppress-comment-regex)