### PR TITLE
fix(package): Change badge-up to @rpl/badge-up to fix vulnerable dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "array.prototype.find": "2.0.4",
     "babel-runtime": "6.23.0",
-    "badge-up": "2.3.0",
+    "@rpl/badge-up": "2.2.0",
     "flow-annotation-check": "1.8.1",
     "glob": "7.1.1",
     "minimatch": "3.0.4",

--- a/src/__tests__/test-report-badge.js
+++ b/src/__tests__/test-report-badge.js
@@ -2,11 +2,11 @@
 
 import path from 'path';
 
-import badge from 'badge-up';
+import badge from '@rpl/badge-up';
 
 const LIB_REPORT_BADGE = '../lib/report-badge';
 const LIB_PROMISIFIED = '../lib/promisified';
-const NPM_BADGE = 'badge-up';
+const NPM_BADGE = '@rpl/badge-up';
 
 beforeEach(() => {
   jest.resetModules();

--- a/src/lib/report-badge.js
+++ b/src/lib/report-badge.js
@@ -4,7 +4,7 @@
 
 import path from 'path';
 
-import badge from 'badge-up';
+import badge from '@rpl/badge-up';
 
 import {mkdirp, writeFile} from './promisified';
 


### PR DESCRIPTION
This PR changes the badge-up npm dependency to the @rpl/badge-up scoped npm package, which is just the original package with the minimal changes needed to update its svgo dependency (See #177 for a rationale).