### PR TITLE
Replace semantic-tablesort with tablesort.js from tristen/tablesort

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -1,7 +1,11 @@
 "use strict";
 
 $(function () {
-  $("table").tablesort();
+  Array.prototype.slice.call(
+    document.getElementsByClassName('sortable')
+  ).forEach(function (table) {
+    new Tablesort(table);
+  });
 
   $('td.error .attention.icon').popup({inline: true});
 });

--- a/assets/tablesort.css
+++ b/assets/tablesort.css
@@ -1,0 +1,19 @@
+.ui.sortable.table thead th[role=columnheader]:after {
+  display: inline-block;
+	-ms-user-select: none;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	user-select: none;
+}
+
+.ui.sortable.table thead th[role=columnheader][aria-sort=ascending]:after {
+  content: '\f0d8';
+}
+
+.ui.sortable.table thead th[role=columnheader][aria-sort=descending]:after {
+  content: '\f0d7';
+}
+
+.ui.sortable.table thead th[role=columnheader][aria-sort] {
+  background: #0000000d;
+}

--- a/assets/tablesort.js
+++ b/assets/tablesort.js
@@ -1,0 +1,254 @@
+;(function() {
+  function Tablesort(el, options) {
+    if (!(this instanceof Tablesort)) return new Tablesort(el, options);
+
+    if (!el || el.tagName !== 'TABLE') {
+      throw new Error('Element must be a table');
+    }
+    this.init(el, options || {});
+  }
+
+  var sortOptions = [];
+
+  var createEvent = function(name) {
+    var evt;
+
+    if (!window.CustomEvent || typeof window.CustomEvent !== 'function') {
+      evt = document.createEvent('CustomEvent');
+      evt.initCustomEvent(name, false, false, undefined);
+    } else {
+      evt = new CustomEvent(name);
+    }
+
+    return evt;
+  };
+
+  var getInnerText = function(el) {
+    return el.getAttribute('data-sort') || el.textContent || el.innerText || '';
+  };
+
+  // Default sort method if no better sort method is found
+  var caseInsensitiveSort = function(a, b) {
+    a = a.trim().toLowerCase();
+    b = b.trim().toLowerCase();
+
+    if (a === b) return 0;
+    if (a < b) return 1;
+
+    return -1;
+  };
+
+  // Stable sort function
+  // If two elements are equal under the original sort function,
+  // then there relative order is reversed
+  var stabilize = function(sort, antiStabilize) {
+    return function(a, b) {
+      var unstableResult = sort(a.td, b.td);
+
+      if (unstableResult === 0) {
+        if (antiStabilize) return b.index - a.index;
+        return a.index - b.index;
+      }
+
+      return unstableResult;
+    };
+  };
+
+  Tablesort.extend = function(name, pattern, sort) {
+    if (typeof pattern !== 'function' || typeof sort !== 'function') {
+      throw new Error('Pattern and sort must be a function');
+    }
+
+    sortOptions.push({
+      name: name,
+      pattern: pattern,
+      sort: sort
+    });
+  };
+
+  Tablesort.prototype = {
+
+    init: function(el, options) {
+      var that = this,
+          firstRow,
+          defaultSort,
+          i,
+          cell;
+
+      that.table = el;
+      that.thead = false;
+      that.options = options;
+
+      if (el.rows && el.rows.length > 0) {
+        if (el.tHead && el.tHead.rows.length > 0) {
+          for (i = 0; i < el.tHead.rows.length; i++) {
+            if (el.tHead.rows[i].getAttribute('data-sort-method') === 'thead') {
+              firstRow = el.tHead.rows[i];
+              break;
+            }
+          }
+          if (!firstRow) {
+            firstRow = el.tHead.rows[el.tHead.rows.length - 1];
+          }
+          that.thead = true;
+        } else {
+          firstRow = el.rows[0];
+        }
+      }
+
+      if (!firstRow) return;
+
+      var onClick = function() {
+        if (that.current && that.current !== this) {
+          that.current.removeAttribute('aria-sort');
+        }
+
+        that.current = this;
+        that.sortTable(this);
+      };
+
+      // Assume first row is the header and attach a click handler to each.
+      for (i = 0; i < firstRow.cells.length; i++) {
+        cell = firstRow.cells[i];
+        cell.setAttribute('role','columnheader');
+        if (cell.getAttribute('data-sort-method') !== 'none') {
+          cell.tabindex = 0;
+          cell.addEventListener('click', onClick, false);
+
+          if (cell.getAttribute('data-sort-default') !== null) {
+            defaultSort = cell;
+          }
+        }
+      }
+
+      if (defaultSort) {
+        that.current = defaultSort;
+        that.sortTable(defaultSort);
+      }
+    },
+
+    sortTable: function(header, update) {
+      var that = this,
+          column = header.cellIndex,
+          sortFunction = caseInsensitiveSort,
+          item = '',
+          items = [],
+          i = that.thead ? 0 : 1,
+          sortMethod = header.getAttribute('data-sort-method'),
+          sortOrder = header.getAttribute('aria-sort');
+
+      that.table.dispatchEvent(createEvent('beforeSort'));
+
+      // If updating an existing sort, direction should remain unchanged.
+      if (!update) {
+        if (sortOrder === 'ascending') {
+          sortOrder = 'descending';
+        } else if (sortOrder === 'descending') {
+          sortOrder = 'ascending';
+        } else {
+          sortOrder = that.options.descending ? 'descending' : 'ascending';
+        }
+
+        header.setAttribute('aria-sort', sortOrder);
+      }
+
+      if (that.table.rows.length < 2) return;
+
+      // If we force a sort method, it is not necessary to check rows
+      if (!sortMethod) {
+        while (items.length < 3 && i < that.table.tBodies[0].rows.length) {
+          item = getInnerText(that.table.tBodies[0].rows[i].cells[column]);
+          item = item.trim();
+
+          if (item.length > 0) {
+            items.push(item);
+          }
+
+          i++;
+        }
+
+        if (!items) return;
+      }
+
+      for (i = 0; i < sortOptions.length; i++) {
+        item = sortOptions[i];
+
+        if (sortMethod) {
+          if (item.name === sortMethod) {
+            sortFunction = item.sort;
+            break;
+          }
+        } else if (items.every(item.pattern)) {
+          sortFunction = item.sort;
+          break;
+        }
+      }
+
+      that.col = column;
+
+      for (i = 0; i < that.table.tBodies.length; i++) {
+        var newRows = [],
+            noSorts = {},
+            j,
+            totalRows = 0,
+            noSortsSoFar = 0;
+
+        if (that.table.tBodies[i].rows.length < 2) continue;
+
+        for (j = 0; j < that.table.tBodies[i].rows.length; j++) {
+          item = that.table.tBodies[i].rows[j];
+          if (item.getAttribute('data-sort-method') === 'none') {
+            // keep no-sorts in separate list to be able to insert
+            // them back at their original position later
+            noSorts[totalRows] = item;
+          } else {
+            // Save the index for stable sorting
+            newRows.push({
+              tr: item,
+              td: getInnerText(item.cells[that.col]),
+              index: totalRows
+            });
+          }
+          totalRows++;
+        }
+        // Before we append should we reverse the new array or not?
+        // If we reverse, the sort needs to be `anti-stable` so that
+        // the double negatives cancel out
+        if (sortOrder === 'descending') {
+          newRows.sort(stabilize(sortFunction, true));
+        } else {
+          newRows.sort(stabilize(sortFunction, false));
+          newRows.reverse();
+        }
+
+        // append rows that already exist rather than creating new ones
+        for (j = 0; j < totalRows; j++) {
+          if (noSorts[j]) {
+            // We have a no-sort row for this position, insert it here.
+            item = noSorts[j];
+            noSortsSoFar++;
+          } else {
+            item = newRows[j - noSortsSoFar].tr;
+          }
+
+          // appendChild(x) moves x if already present somewhere else in the DOM
+          that.table.tBodies[i].appendChild(item);
+        }
+      }
+
+      that.table.dispatchEvent(createEvent('afterSort'));
+    },
+
+    refresh: function() {
+      if (this.current !== undefined) {
+        this.sortTable(this.current, true);
+      }
+    }
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Tablesort;
+  } else {
+    window.Tablesort = Tablesort;
+  }
+})();

--- a/assets/tablesort.number.js
+++ b/assets/tablesort.number.js
@@ -1,0 +1,21 @@
+;(function(){
+  var cleanNumber = function(i) {
+    return i.replace(/[^\-?0-9.]/g, '');
+  },
+
+  compareNumber = function(a, b) {
+    var fa = parseFloat(a);
+    var fb = parseFloat(b);
+
+    na = isNaN(fa) ? 0 : fa;
+    nb = isNaN(fb) ? 0 : fb;
+
+    return fa - fb;
+  };
+
+  Tablesort.extend('number', function(item) {
+    return item.match(/^[-+]?(\d)*-?([,\.]){0,1}-?(\d)+([E,e][\-+][\d]+)?\s?%?$/); // Number
+  }, function(a, b) {
+    return compareNumber(cleanNumber(b), cleanNumber(a));
+  });
+}());

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-sourcefile.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-sourcefile.js.snap
@@ -32,7 +32,7 @@ exports[`<HTMLReportBodySourceFile /> 1`] = `
         <thead>
           <tr>
             <th
-              className="sorted ascending"
+              data-sort-default={true}
             >
               Filename
             </th>

--- a/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-body-coverage-summary.js.snap
@@ -75,7 +75,7 @@ exports[`<HTMLReportBodySummary /> 1`] = `
         <thead>
           <tr>
             <th
-              className="sorted ascending"
+              data-sort-default={true}
             >
               Filename
             </th>
@@ -403,7 +403,7 @@ exports[`<HTMLReportBodySummary /> 2`] = `
         <thead>
           <tr>
             <th
-              className="sorted ascending"
+              data-sort-default={true}
             >
               Filename
             </th>

--- a/src/__tests__/react-components/__snapshots__/test-coverage-file-table-head.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-coverage-file-table-head.js.snap
@@ -4,7 +4,7 @@ exports[`<FlowCoverageFileTableHead /> 1`] = `
 <thead>
   <tr>
     <th
-      className="sorted ascending"
+      data-sort-default={true}
     >
       Filename
     </th>

--- a/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
+++ b/src/__tests__/react-components/__snapshots__/test-html-report-page.js.snap
@@ -81,7 +81,7 @@ exports[`<HTMLReportSummaryPage/> 1`] = `
           <thead>
             <tr>
               <th
-                className="sorted ascending"
+                data-sort-default={true}
               >
                 Filename
               </th>

--- a/src/lib/components/coverage-file-table-head.jsx
+++ b/src/lib/components/coverage-file-table-head.jsx
@@ -8,7 +8,7 @@ export default function FlowCoverageFileTableHead() {
   return (
     <thead>
       <tr>
-        <th key="filename" className="sorted ascending">Filename</th>
+        <th key="filename" data-sort-default>Filename</th>
         <th key="annotation">Annotation</th>
         <th key="percent">Percent</th>
         <th key="total">Total</th>

--- a/src/lib/report-html.js
+++ b/src/lib/report-html.js
@@ -17,7 +17,9 @@ const assetsList: Array<string> = [
   'jquery-3.1.0.min.js',
   'semantic.min.js',
   'semantic.min.css',
-  'semantic-tablesort.js',
+  'tablesort.css',
+  'tablesort.js',
+  'tablesort.number.js',
   'index.js',
   'codemirror.js',
   'codemirror.css',
@@ -91,12 +93,14 @@ function renderHTMLReport(opt/* : Object */)/* : Promise<*> */ {
           assets: {
             css: [
               'semantic.min.css',
+              'tablesort.css',
               'flow-coverage-report.css'
             ].map(prefixAssets).map(toRelative),
             js: [
               'jquery-3.1.0.min.js',
               'semantic.min.js',
-              'semantic-tablesort.js',
+              'tablesort.js',
+              'tablesort.number.js',
               'index.js'
             ].map(prefixAssets).map(toRelative)
           }
@@ -130,6 +134,7 @@ function renderHTMLReport(opt/* : Object */)/* : Promise<*> */ {
                   assets: {
                     css: [
                       'semantic.min.css',
+                      'tablesort.css',
                       'codemirror.css',
                       'flow-highlight-source.css',
                       'flow-coverage-report.css',
@@ -138,7 +143,8 @@ function renderHTMLReport(opt/* : Object */)/* : Promise<*> */ {
                     js: [
                       'jquery-3.1.0.min.js',
                       'semantic.min.js',
-                      'semantic-tablesort.js',
+                      'tablesort.js',
+                      'tablesort.number.js',
                       'codemirror.js',
                       'codemirror-javascript-mode.js',
                       'codemirror-annotatescrollbar-addon.js',


### PR DESCRIPTION
By using a sort method that skips jQuery it will be much faster and use less CPU to sort a large list.

See #176

With a synthetic page of ~4800 rows the sort now takes ~150ms with an extra ~650ms for each of style + layout. 

<img width="1059" alt="screenshot 2018-12-22 16 53 47" src="https://user-images.githubusercontent.com/187460/50378898-5e1e6280-060a-11e9-8fcd-7c8fb591b1cd.png">

I didn't get scientific measuring the new sort speed, but the numbers look much better than before.