### PR TITLE
Upgrade mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "flow-annotation-check": "1.3.0",
     "glob": "7.1.1",
     "minimatch": "3.0.4",
-    "mkdirp": "0.5.1",
+    "mkdirp": "^0.5.5",
     "parse-json": "2.2.0",
     "react": "15.5.4",
     "react-dom": "15.5.4",


### PR DESCRIPTION
This upgrades mkdirp to latest compatible version, and uses the "^" compatible version for it, to ease future upgrades in dependent packages.