### PR TITLE
docs: Add info about how the -t option works

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,16 @@ If the **flow** executable is not in your PATH, you can specified it using the
 flow-coverage-report -f /path/to/flow ...
 ```
 
-To customize the output dir (which defaults to `flow-coverage/`). you can use the `-o` option:
+To customize the output dir (which defaults to `flow-coverage/`) you can use the `-o` option. Though by default the output type is `text` meaning that it ouputs to the console. Use `-o` in conjunction with `-t` to save your desired format:
 
 ```
 flow-coverage-report -o my-custom-flow-coverage-dir/
+```
+
+To customize the type you can use `-t` options:
+
+```
+flow-coverage-report -t html
 ```
 
 ### Load default options from a JSON config file


### PR DESCRIPTION
Just started using the library and was immediately confused, this PR describes how the `text` type works so that I don't get immediately confused with why it's not saving to `/flow-coverage`.

Found out how to use it properly from #160